### PR TITLE
Add Claude Max plan usage tracking and session monitoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
 
-A beautiful real-time terminal monitoring tool for Claude AI token usage. Track your token consumption, burn rate, and get predictions about when you'll run out of tokens.
+A beautiful real-time terminal monitoring tool for Claude AI token usage. Track your token consumption, burn rate, monthly session usage, and get predictions about when you'll run out of tokens.
 
 ![Claude Token Monitor Screenshot](doc/sc.png)
 
@@ -42,8 +42,10 @@ A beautiful real-time terminal monitoring tool for Claude AI token usage. Track 
 ## ✨ Features
 
 - **🔄 Real-time monitoring** - Updates every 3 seconds with smooth refresh
-- **📊 Visual progress bars** - Beautiful color-coded token and time progress bars
-- **🔮 Smart predictions** - Calculates when tokens will run out based on current burn rate
+- **📊 Visual progress bars** - Beautiful color-coded token, time, sessions, and prediction progress bars
+- **📅 Monthly session tracking** - Monitor your usage against the 50 sessions/month Max plan limit
+- **🔮 Session predictions** - Estimates total tokens for current session based on burn rate
+- **📊 Historical analytics** - Tracks maximum burn rate from previous sessions
 - **🤖 Auto-detection** - Automatically switches to custom max when Pro limit is exceeded
 - **📋 Multiple plan support** - Works with Pro, Max5, Max20, and auto-detect plans
 - **⚠️ Warning system** - Alerts when tokens exceed limits or will deplete before session reset
@@ -174,6 +176,17 @@ The monitor calculates burn rate based on all sessions from the last hour:
 - Analyzes token consumption across overlapping sessions
 - Provides accurate recent usage patterns
 - Updates predictions in real-time
+
+### Monthly Session Tracking
+
+For Claude Max plan users, the monitor tracks:
+
+- **Current month usage**: Counts non-gap billing blocks as sessions
+- **Sessions remaining**: Shows how many of your 50 monthly sessions are left
+- **Usage pace**: Visual progress bar showing monthly consumption
+- **Historical maximum**: Tracks your highest burn rate from previous sessions
+
+> **📅 Note**: Each 5-hour billing window counts as one session. Consecutive sessions without breaks each count toward your monthly limit.
 
 ---
 


### PR DESCRIPTION
## Summary
  • **Monthly Session Tracking**: Visual progress bar showing x/50 sessions used against Claude Max plan limit
  • **Session Predictions**: Estimates total tokens for current session based on real-time burn rate
  • **Historical Analytics**: Tracks maximum burn rate from previous sessions for better usage planning
  • **Enhanced Progress Bars**: Added orange session usage bar and purple prediction bar with consistent styling

  ## New Features Added
  - ✅ Monthly session counter with remaining sessions display
  - ✅ Current session prediction showing estimated total token consumption
  - ✅ Historical maximum burn rate tracking from completed sessions
  - ✅ Visual progress bars for all trackable metrics (sessions used, session predictions)
  - ✅ Comprehensive README documentation with new features explained

  ## Technical Improvements
  - Fixed session counting logic to properly handle Anthropic's 5-hour billing windows
  - Added three new progress bar functions with consistent color coding
  - Integrated monthly usage calculations into main monitoring loop
  - Enhanced the display with clear labeling ("Session Predicted" vs "Predicted Total")

  ## Test Plan
  - [x] Script runs without errors and shows all new progress bars
  - [x] Session counting accurately reflects billing blocks (non-gap sessions)
  - [x] Progress bars display correctly with proper percentages
  - [x] README documentation is comprehensive and accurate
  - [x] All existing functionality preserved

  This addresses the critical need for Claude Max plan users to track their monthly session usage against the 50 session limit, providing early warning when approaching
  limits.

  🤖 Generated with [Claude Code](https://claude.ai/code)