### PR TITLE
enh: Implement basic package scaffolding, add guided setup, update readme 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ A beautiful real-time terminal monitoring tool for Claude AI token usage. Track 
 
 - [✨ Key Features](#-key-features)
 - [🚀 Installation](#-installation)
-  - [⚡ Quick Start](#-quick-start)
+  - [⚡ Quick Start with uv (Recommended)](#-quick-start-with-uv-recommended)
+  - [⚡ Alternative Quick Start](#-alternative-quick-start)
   - [🔒 Production Setup (Recommended)](#-production-setup-recommended)
   - [Virtual Environment Setup](#virtual-environment-setup)
 - [📖 Usage](#-usage)
@@ -44,14 +45,34 @@ A beautiful real-time terminal monitoring tool for Claude AI token usage. Track 
 - **⚠️ Warning system** - Alerts when tokens exceed limits or will deplete before session reset
 - **💼 Professional UI** - Clean, colorful terminal interface with emojis
 - **⏰ Customizable scheduling** - Set your own reset times and timezones
+- **📦 Zero-config setup** - One-command install with uv, automatic dependency management
 
 ---
 
 ## 🚀 Installation
 
-### ⚡ Quick Start
+### ⚡ Quick Start with uv (Recommended)
 
-For immediate testing (not recommended for regular use):
+The fastest and most reliable way to run the monitor:
+
+```bash
+# Install uv (if not already installed)
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and run with automatic dependency management
+git clone https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor.git
+cd Claude-Code-Usage-Monitor
+uv run ccusage_monitor.py
+```
+
+The tool will automatically:
+- ✅ Create an isolated Python environment
+- ✅ Install Python dependencies (`pytz`)
+- ✅ Check for `ccusage` npm package and prompt to install if missing
+
+### ⚡ Alternative Quick Start
+
+For immediate testing without uv:
 
 ```bash
 # Install dependencies
@@ -169,7 +190,10 @@ deactivate
 
 Create an alias for quick access:
 ```bash
-# Add to ~/.bashrc or ~/.zshrc
+# For uv (recommended)
+alias claude-monitor='cd ~/Claude-Code-Usage-Monitor && uv run ccusage_monitor.py'
+
+# For traditional setup
 alias claude-monitor='cd ~/Claude-Code-Usage-Monitor && source venv/bin/activate && ./ccusage_monitor.py'
 
 # Then just run:
@@ -183,7 +207,10 @@ claude-monitor
 ### Basic Usage
 
 ```bash
-# Default (Pro plan - 7,000 tokens)
+# With uv (recommended)
+uv run ccusage_monitor.py
+
+# Traditional method
 ./ccusage_monitor.py
 
 # Exit the monitor
@@ -195,26 +222,28 @@ claude-monitor
 #### Specify Your Plan
 
 ```bash
-# Pro plan (~7,000 tokens) - Default
+# With uv (recommended)
+uv run ccusage_monitor.py --plan pro    # Pro plan (~7,000 tokens) - Default
+uv run ccusage_monitor.py --plan max5   # Max5 plan (~35,000 tokens)
+uv run ccusage_monitor.py --plan max20  # Max20 plan (~140,000 tokens)
+uv run ccusage_monitor.py --plan custom_max  # Auto-detect from highest previous session
+
+# Traditional method
 ./ccusage_monitor.py --plan pro
-
-# Max5 plan (~35,000 tokens)
 ./ccusage_monitor.py --plan max5
-
-# Max20 plan (~140,000 tokens)
 ./ccusage_monitor.py --plan max20
-
-# Auto-detect from highest previous session
 ./ccusage_monitor.py --plan custom_max
 ```
 
 #### Custom Reset Times
 
 ```bash
-# Reset at 3 AM
-./ccusage_monitor.py --reset-hour 3
+# With uv (recommended)
+uv run ccusage_monitor.py --reset-hour 3   # Reset at 3 AM
+uv run ccusage_monitor.py --reset-hour 22  # Reset at 10 PM
 
-# Reset at 10 PM
+# Traditional method
+./ccusage_monitor.py --reset-hour 3
 ./ccusage_monitor.py --reset-hour 22
 ```
 
@@ -223,16 +252,16 @@ claude-monitor
 The default timezone is **Europe/Warsaw**. Change it to any valid timezone:
 
 ```bash
-# Use US Eastern Time
+# With uv (recommended)
+uv run ccusage_monitor.py --timezone US/Eastern      # US Eastern Time
+uv run ccusage_monitor.py --timezone Asia/Tokyo      # Tokyo time
+uv run ccusage_monitor.py --timezone UTC             # UTC
+uv run ccusage_monitor.py --timezone Europe/London   # London time
+
+# Traditional method
 ./ccusage_monitor.py --timezone US/Eastern
-
-# Use Tokyo time
 ./ccusage_monitor.py --timezone Asia/Tokyo
-
-# Use UTC
 ./ccusage_monitor.py --timezone UTC
-
-# Use London time
 ./ccusage_monitor.py --timezone Europe/London
 ```
 

--- a/ccusage_monitor.py
+++ b/ccusage_monitor.py
@@ -10,6 +10,41 @@ import argparse
 import pytz
 
 
+def check_ccusage_dependency():
+    """Check if ccusage is installed and prompt to install if not."""
+    try:
+        # Check if ccusage is available
+        subprocess.run(['ccusage', '--version'], capture_output=True, check=True)
+        return True
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        print("📦 ccusage dependency not found.")
+        print("This tool requires the 'ccusage' npm package to function.")
+        print()
+        
+        # Check if npm is available
+        try:
+            subprocess.run(['npm', '--version'], capture_output=True, check=True)
+        except FileNotFoundError:
+            print("❌ npm not found. Please install Node.js and npm first.")
+            print("Then run: npm install -g ccusage")
+            return False
+        
+        response = input("Would you like to install it now? (y/N): ").strip().lower()
+        if response in ['y', 'yes']:
+            try:
+                print("Installing ccusage...")
+                subprocess.run(['npm', 'install', '-g', 'ccusage'], check=True)
+                print("✅ ccusage installed successfully!")
+                return True
+            except subprocess.CalledProcessError as e:
+                print(f"❌ Failed to install ccusage: {e}")
+                print("Please install manually: npm install -g ccusage")
+                return False
+        else:
+            print("Please install ccusage manually: npm install -g ccusage")
+            return False
+
+
 def run_ccusage():
     """Execute ccusage blocks --json command and return parsed JSON data."""
     try:
@@ -249,6 +284,10 @@ def get_token_limit(plan, blocks=None):
 def main():
     """Main monitoring loop."""
     args = parse_args()
+    
+    # Check ccusage dependency first
+    if not check_ccusage_dependency():
+        sys.exit(1)
     
     # For 'custom_max' plan, we need to get data first to determine the limit
     if args.plan == 'custom_max':

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "claude-code-usage-monitor"
+version = "1.0.0"
+description = "Real-time terminal monitoring tool for Claude AI token usage"
+readme = "README.md"
+requires-python = ">=3.6"
+dependencies = [
+    "pytz",
+]
+
+[project.scripts]
+ccusage-monitor = "ccusage_monitor:main"

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,23 @@
+version = 1
+revision = 2
+requires-python = ">=3.6"
+
+[[package]]
+name = "claude-code-usage-monitor"
+version = "1.0.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pytz" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pytz" }]
+
+[[package]]
+name = "pytz"
+version = "2025.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f8/bf/abbd3cdfb8fbc7fb3d4d38d320f2441b1e7cbe29be4f23797b4a2b5d8aac/pytz-2025.2.tar.gz", hash = "sha256:360b9e3dbb49a209c21ad61809c7fb453643e048b38924c765813546746e81c3", size = 320884, upload_time = "2025-03-25T02:25:00.538Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/c4/34e93fe5f5429d7570ec1fa436f1986fb1f00c3e0f43a589fe2bbcd22c3f/pytz-2025.2-py2.py3-none-any.whl", hash = "sha256:5ddf76296dd8c44c26eb8f4b6f35488f3ccbf6fbbd7adee0b7262d43f0ec2f00", size = 509225, upload_time = "2025-03-25T02:24:58.468Z" },
+]


### PR DESCRIPTION
> PR would close #7 
@Maciek-roboblog this will now build clean as a basic package so you can upload to pypi and let folks run with no pull via `uvx ccusage_monitor` or whatever you want to call the package name. Left most of the metadata out of pyproject so you can populate however you want but this will be a big help getting a great idea in front of folks. If you're open to it love to submit a different branch with some nice little ui tweaks especially for folks who drive a dark color theme (some of the words are invisible on a blue shell)

  Key Updates Made:

  1. Reorganized Installation Section:
    - Made "Quick Start with uv" the primary recommendation
    - Moved traditional pip/venv approach to "Alternative Quick Start"
    - Added clear benefits of using uv (automatic environment, dependency management, ccusage checking)
  2. Updated Table of Contents to reflect new structure
  3. Enhanced Key Features with "Zero-config setup" highlighting uv's ease of use
  4. Updated Usage Examples throughout:
    - All configuration options now show uv examples first
    - Traditional methods included as alternatives
    - Consistent formatting across all sections
  5. Updated Shell Alias section with uv-specific alias

  The README now properly promotes uv as the recommended approach while maintaining backward compatibility information for users who prefer traditional Python tooling. The tool is
  now ready for reproducible usage with minimal setup complexity.

> Great. Now, write a concise pull request message in markdown format for this change

⏺ ## Add uv Support for Zero-Config Setup

  Implements reproducible Python package management using uv with automatic dependency handling.

  ### Changes

  - **Added `pyproject.toml`** with minimal Python dependencies (`pytz`)
  - **Enhanced `ccusage_monitor.py`** with automatic ccusage dependency checking and user-prompted installation
  - **Updated README.md** to promote `uv run ccusage_monitor.py` as the recommended installation method

  ### Benefits

  - **Zero-config setup**: Single command `uv run ccusage_monitor.py` handles everything
  - **Automatic isolation**: Creates isolated Python environment without manual venv setup
  - **Dependency management**: Automatically installs Python deps and prompts for npm ccusage package
  - **Backward compatible**: Traditional pip/venv methods still supported

  ### Usage

  ```bash
  # New recommended method
  uv run ccusage_monitor.py

  # All options work the same way
  uv run ccusage_monitor.py --plan max5 --timezone US/Eastern
```

https://github.com/user-attachments/assets/eec43c8d-c10d-4d2c-b596-650b2e960826

### Output
Successfully builds via `uv build`:
```
(base) ➜  Claude-Code-Usage-Monitor git:(uv_for_you_and_me) uv build
Building source distribution...
running egg_info
...
running install_scripts
creating build/bdist.macosx-11.1-arm64/wheel/claude_code_usage_monitor-1.0.0.dist-info/WHEEL
creating '/Users/taylorwilsdon/git/Claude-Code-Usage-Monitor/dist/.tmp-50qixdun/claude_code_usage_monitor-1.0.0-py3-none-any.whl' and adding 'build/bdist.macosx-11.1-arm64/wheel' to it
adding 'ccusage_monitor.py'
adding 'claude_code_usage_monitor-1.0.0.dist-info/licenses/LICENSE'
adding 'claude_code_usage_monitor-1.0.0.dist-info/METADATA'
adding 'claude_code_usage_monitor-1.0.0.dist-info/WHEEL'
adding 'claude_code_usage_monitor-1.0.0.dist-info/entry_points.txt'
adding 'claude_code_usage_monitor-1.0.0.dist-info/top_level.txt'
adding 'claude_code_usage_monitor-1.0.0.dist-info/RECORD'
removing build/bdist.macosx-11.1-arm64/wheel
Successfully built dist/claude_code_usage_monitor-1.0.0.tar.gz
Successfully built dist/claude_code_usage_monitor-1.0.0-py3-none-any.whl`