### PR TITLE
Update README.md with CLAUDE_CONFIG_DIR path

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ claude-monitor
 
 ### Configuration Options
 
+#### Specify Claude Config Path
+
+If you are getting error `No active session found`, you may need to specify custom Claude Code config path. Now it is `~/.config/claude`:
+
+```bash
+CLAUDE_CONFIG_DIR=~/.config/claude ./ccusage_monitor.py
+```
+
 #### Specify Your Plan
 
 ```bash


### PR DESCRIPTION
Information about CLAUDE_CONFIG_DIR added to README as claude code uses now `~/.config/.claude` path as described here: https://github.com/ryoppippi/ccusage/issues/121



Based on issue: https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor/issues/14
