### PR TITLE
Docs: Add Star History chart to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -614,3 +614,9 @@ This tool builds upon the excellent [ccusage](https://github.com/ryoppippi/ccusa
 [Report Bug](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor/issues) • [Request Feature](https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor/issues) • [Contribute](CONTRIBUTING.md)
 
 </div>
+
+---
+
+## Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=Maciek-roboblog/Claude-Code-Usage-Monitor&type=Date)](https://www.star-history.com/#Maciek-roboblog/Claude-Code-Usage-Monitor&Date)


### PR DESCRIPTION
I noticed that many popular open-source projects include a star history chart in their README to visualize community growth and engagement. I thought it would be a great addition to this project as well.

This PR adds a dynamic Star History chart to the end of the `README.md`.