### PR TITLE
Fix apparent typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The fastest and easiest way to install and use the monitor:
 uv tool install claude-usage-monitor
 
 # Run from anywhere
-claude-usage-monitor
+claude-monitor
 ```
 
 #### Install from Source


### PR DESCRIPTION
The executable appears to be `claude-monitor`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to correct the example command for running the tool after installation, changing it from `claude-usage-monitor` to `claude-monitor`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->