### PR TITLE
fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ The fastest and easiest way to install and use the monitor:
 uv tool install claude-usage-monitor
 
 # Run from anywhere
-claude-usage-monitor
+claude-monitor
 ```
 
 #### Install from Source


### PR DESCRIPTION
the command from installing via uv remains `claude-monitor`. the readme does not reflect that correctly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the README to reflect the new command name for running the tool, changing it from `claude-usage-monitor` to `claude-monitor` in the installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->