### PR TITLE
Add: Daily and monthly token usage views

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -212,3 +212,7 @@ logs/
 /src/Functionality_Coverage_Claude-Code-Usage-Monitor_Missing_From_claude_monitor.md
 /TODO.md
 *Zone.Identifier
+
+# Local linting scripts
+lint*.py
+lint*.sh

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -6,7 +6,6 @@ import logging
 import signal
 import sys
 import time
-import threading
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Union

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -7,34 +7,41 @@ import signal
 import sys
 import time
 import traceback
+
 from pathlib import Path
-from typing import Any, Callable, Dict, List, NoReturn, Optional, Union
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import NoReturn
+from typing import Optional
+from typing import Union
 
 from rich.console import Console
 
 from claude_monitor import __version__
-from claude_monitor.cli.bootstrap import (
-    ensure_directories,
-    init_timezone,
-    setup_environment,
-    setup_logging,
-)
-from claude_monitor.core.plans import Plans, PlanType, get_token_limit
+from claude_monitor.cli.bootstrap import ensure_directories
+from claude_monitor.cli.bootstrap import init_timezone
+from claude_monitor.cli.bootstrap import setup_environment
+from claude_monitor.cli.bootstrap import setup_logging
+from claude_monitor.core.plans import Plans
+from claude_monitor.core.plans import PlanType
+from claude_monitor.core.plans import get_token_limit
 from claude_monitor.core.settings import Settings
 from claude_monitor.data.aggregator import UsageAggregator
 from claude_monitor.data.analysis import analyze_usage
 from claude_monitor.error_handling import report_error
 from claude_monitor.monitoring.orchestrator import MonitoringOrchestrator
-from claude_monitor.terminal.manager import (
-    enter_alternate_screen,
-    handle_cleanup_and_exit,
-    handle_error_and_exit,
-    restore_terminal,
-    setup_terminal,
-)
-from claude_monitor.terminal.themes import get_themed_console, print_themed
+from claude_monitor.terminal.manager import enter_alternate_screen
+from claude_monitor.terminal.manager import handle_cleanup_and_exit
+from claude_monitor.terminal.manager import handle_error_and_exit
+from claude_monitor.terminal.manager import restore_terminal
+from claude_monitor.terminal.manager import setup_terminal
+from claude_monitor.terminal.themes import get_themed_console
+from claude_monitor.terminal.themes import print_themed
 from claude_monitor.ui.display_controller import DisplayController
 from claude_monitor.ui.table_views import TableViewsController
+
 
 # Type aliases for CLI callbacks
 DataUpdateCallback = Callable[[Dict[str, Any]], None]
@@ -164,9 +171,9 @@ def _run_monitoring(args: argparse.Namespace) -> None:
             live_display.update(loading_display)
 
             orchestrator = MonitoringOrchestrator(
-                update_interval=args.refresh_rate
-                if hasattr(args, "refresh_rate")
-                else 10,
+                update_interval=(
+                    args.refresh_rate if hasattr(args, "refresh_rate") else 10
+                ),
                 data_path=str(data_path),
             )
             orchestrator.set_args(args)

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -8,6 +8,8 @@ import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Union
 
+from rich.console import Console
+
 from claude_monitor import __version__
 from claude_monitor.cli.bootstrap import (
     ensure_directories,
@@ -17,6 +19,7 @@ from claude_monitor.cli.bootstrap import (
 )
 from claude_monitor.core.plans import Plans, PlanType, get_token_limit
 from claude_monitor.core.settings import Settings
+from claude_monitor.data.aggregator import UsageAggregator
 from claude_monitor.data.analysis import analyze_usage
 from claude_monitor.error_handling import report_error
 from claude_monitor.monitoring.orchestrator import MonitoringOrchestrator
@@ -29,6 +32,7 @@ from claude_monitor.terminal.manager import (
 )
 from claude_monitor.terminal.themes import get_themed_console, print_themed
 from claude_monitor.ui.display_controller import DisplayController
+from claude_monitor.ui.table_views import TableViewsController
 
 # Type aliases for CLI callbacks
 DataUpdateCallback = Callable[[Dict[str, Any]], None]
@@ -103,6 +107,8 @@ def main(argv: Optional[List[str]] = None) -> int:
 
 def _run_monitoring(args: argparse.Namespace) -> None:
     """Main monitoring implementation without facade."""
+    view_mode = getattr(args, "view", "realtime")
+    
     if hasattr(args, "theme") and args.theme:
         console = get_themed_console(force_theme=args.theme.lower())
     else:
@@ -120,6 +126,11 @@ def _run_monitoring(args: argparse.Namespace) -> None:
         data_path: Path = data_paths[0]
         logger = logging.getLogger(__name__)
         logger.info(f"Using data path: {data_path}")
+        
+        # Handle different view modes
+        if view_mode in ["daily", "monthly"]:
+            _run_table_view(args, data_path, view_mode, console)
+            return
 
         token_limit: int = _get_initial_token_limit(args, str(data_path))
 
@@ -360,6 +371,54 @@ def validate_cli_environment() -> Optional[str]:
 
     except Exception as e:
         return f"Environment validation failed: {e}"
+
+
+def _run_table_view(
+    args: argparse.Namespace, data_path: Path, view_mode: str, console: Console
+) -> None:
+    """Run table view mode (daily/monthly)."""
+    logger = logging.getLogger(__name__)
+    
+    try:
+        # Create aggregator with appropriate mode
+        aggregator = UsageAggregator(
+            data_path=str(data_path),
+            aggregation_mode=view_mode,
+            timezone=args.timezone,
+        )
+        
+        # Create table controller
+        controller = TableViewsController(console=console)
+        
+        # Get aggregated data
+        logger.info(f"Loading {view_mode} usage data...")
+        aggregated_data = aggregator.aggregate()
+        
+        if not aggregated_data:
+            print_themed(f"No usage data found for {view_mode} view", style="warning")
+            return
+            
+        # Display the table
+        controller.display_aggregated_view(
+            data=aggregated_data,
+            view_mode=view_mode,
+            timezone=args.timezone,
+            plan=args.plan,
+            token_limit=_get_initial_token_limit(args, data_path),
+        )
+        
+        # Wait for user to press Ctrl+C
+        print_themed("\nPress Ctrl+C to exit", style="info")
+        try:
+            while True:
+                import time
+                time.sleep(1)
+        except KeyboardInterrupt:
+            print_themed("\nExiting...", style="info")
+        
+    except Exception as e:
+        logger.error(f"Error in table view: {e}", exc_info=True)
+        print_themed(f"Error displaying {view_mode} view: {e}", style="error")
 
 
 if __name__ == "__main__":

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -7,41 +7,34 @@ import signal
 import sys
 import time
 import traceback
-
 from pathlib import Path
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import NoReturn
-from typing import Optional
-from typing import Union
+from typing import Any, Callable, Dict, List, NoReturn, Optional, Union
 
 from rich.console import Console
 
 from claude_monitor import __version__
-from claude_monitor.cli.bootstrap import ensure_directories
-from claude_monitor.cli.bootstrap import init_timezone
-from claude_monitor.cli.bootstrap import setup_environment
-from claude_monitor.cli.bootstrap import setup_logging
-from claude_monitor.core.plans import Plans
-from claude_monitor.core.plans import PlanType
-from claude_monitor.core.plans import get_token_limit
+from claude_monitor.cli.bootstrap import (
+    ensure_directories,
+    init_timezone,
+    setup_environment,
+    setup_logging,
+)
+from claude_monitor.core.plans import Plans, PlanType, get_token_limit
 from claude_monitor.core.settings import Settings
 from claude_monitor.data.aggregator import UsageAggregator
 from claude_monitor.data.analysis import analyze_usage
 from claude_monitor.error_handling import report_error
 from claude_monitor.monitoring.orchestrator import MonitoringOrchestrator
-from claude_monitor.terminal.manager import enter_alternate_screen
-from claude_monitor.terminal.manager import handle_cleanup_and_exit
-from claude_monitor.terminal.manager import handle_error_and_exit
-from claude_monitor.terminal.manager import restore_terminal
-from claude_monitor.terminal.manager import setup_terminal
-from claude_monitor.terminal.themes import get_themed_console
-from claude_monitor.terminal.themes import print_themed
+from claude_monitor.terminal.manager import (
+    enter_alternate_screen,
+    handle_cleanup_and_exit,
+    handle_error_and_exit,
+    restore_terminal,
+    setup_terminal,
+)
+from claude_monitor.terminal.themes import get_themed_console, print_themed
 from claude_monitor.ui.display_controller import DisplayController
 from claude_monitor.ui.table_views import TableViewsController
-
 
 # Type aliases for CLI callbacks
 DataUpdateCallback = Callable[[Dict[str, Any]], None]

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -3,7 +3,10 @@
 import argparse
 import contextlib
 import logging
+import signal
 import sys
+import threading
+import time
 import traceback
 from pathlib import Path
 from typing import Any, Callable, Dict, List, NoReturn, Optional, Union
@@ -224,11 +227,21 @@ def _run_monitoring(args: argparse.Namespace) -> None:
             if not orchestrator.wait_for_initial_data(timeout=10.0):
                 logger.warning("Timeout waiting for initial data")
 
-            # Main loop - live display is already active
-            while True:
-                import time
-
-                time.sleep(1)
+            # Main loop - use event to wait for shutdown signal
+            shutdown_event = threading.Event()
+            
+            def signal_handler(signum, frame):
+                """Handle shutdown signals."""
+                logger.info(f"Received signal {signum}, shutting down...")
+                shutdown_event.set()
+            
+            # Register signal handlers (Windows-compatible)
+            if sys.platform != "win32":
+                signal.signal(signal.SIGTERM, signal_handler)
+            signal.signal(signal.SIGINT, signal_handler)
+            
+            # Wait for shutdown signal
+            shutdown_event.wait()
         finally:
             # Stop monitoring first
             if "orchestrator" in locals():
@@ -410,9 +423,17 @@ def _run_table_view(
         # Wait for user to press Ctrl+C
         print_themed("\nPress Ctrl+C to exit", style="info")
         try:
-            while True:
-                import time
-                time.sleep(1)
+            # Use event-based waiting instead of busy loop
+            exit_event = threading.Event()
+            
+            def exit_handler(signum, frame):
+                """Handle exit signal."""
+                exit_event.set()
+            
+            signal.signal(signal.SIGINT, exit_handler)
+            exit_event.wait()
+            
+            print_themed("\nExiting...", style="info")
         except KeyboardInterrupt:
             print_themed("\nExiting...", style="info")
         

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -5,7 +5,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 import pytz
 from pydantic import Field, field_validator
@@ -33,6 +33,7 @@ class LastUsedParams:
                 "time_format": settings.time_format,
                 "refresh_rate": settings.refresh_rate,
                 "reset_hour": settings.reset_hour,
+                "view": settings.view,
                 "timestamp": datetime.now().isoformat(),
             }
 
@@ -101,6 +102,11 @@ class Settings(BaseSettings):
     plan: Literal["pro", "max5", "max20", "custom"] = Field(
         default="custom",
         description="Plan type (pro, max5, max20, custom)",
+    )
+    
+    view: Literal["realtime", "daily", "monthly", "session"] = Field(
+        default="realtime",
+        description="View mode (realtime, daily, monthly, session)",
     )
 
     @staticmethod
@@ -175,6 +181,20 @@ class Settings(BaseSettings):
                 return v_lower
             raise ValueError(
                 f"Invalid plan: {v}. Must be one of: {', '.join(valid_plans)}"
+            )
+        return v
+    
+    @field_validator("view", mode="before")
+    @classmethod
+    def validate_view(cls, v: Any) -> str:
+        """Validate and normalize view value."""
+        if isinstance(v, str):
+            v_lower = v.lower()
+            valid_views = ["realtime", "daily", "monthly", "session"]
+            if v_lower in valid_views:
+                return v_lower
+            raise ValueError(
+                f"Invalid view: {v}. Must be one of: {', '.join(valid_views)}"
             )
         return v
 
@@ -319,6 +339,7 @@ class Settings(BaseSettings):
         args = argparse.Namespace()
 
         args.plan = self.plan
+        args.view = self.view
         args.timezone = self.timezone
         args.theme = self.theme
         args.refresh_rate = self.refresh_rate

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -3,25 +3,15 @@
 import argparse
 import json
 import logging
-
 from datetime import datetime
 from pathlib import Path
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Literal
-from typing import Optional
-from typing import Tuple
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pytz
-
-from pydantic import Field
-from pydantic import field_validator
-from pydantic_settings import BaseSettings
-from pydantic_settings import SettingsConfigDict
+from pydantic import Field, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from claude_monitor import __version__
-
 
 logger = logging.getLogger(__name__)
 
@@ -323,8 +313,10 @@ class Settings(BaseSettings):
         if settings.theme == "auto" or (
             "theme" not in cli_provided_fields and not clear_config
         ):
-            from claude_monitor.terminal.themes import BackgroundDetector
-            from claude_monitor.terminal.themes import BackgroundType
+            from claude_monitor.terminal.themes import (
+                BackgroundDetector,
+                BackgroundType,
+            )
 
             detector = BackgroundDetector()
             detected_bg = detector.detect_background()

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -3,15 +3,25 @@
 import argparse
 import json
 import logging
+
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Literal
+from typing import Optional
+from typing import Tuple
 
 import pytz
-from pydantic import Field, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+
+from pydantic import Field
+from pydantic import field_validator
+from pydantic_settings import BaseSettings
+from pydantic_settings import SettingsConfigDict
 
 from claude_monitor import __version__
+
 
 logger = logging.getLogger(__name__)
 
@@ -313,10 +323,8 @@ class Settings(BaseSettings):
         if settings.theme == "auto" or (
             "theme" not in cli_provided_fields and not clear_config
         ):
-            from claude_monitor.terminal.themes import (
-                BackgroundDetector,
-                BackgroundType,
-            )
+            from claude_monitor.terminal.themes import BackgroundDetector
+            from claude_monitor.terminal.themes import BackgroundType
 
             detector = BackgroundDetector()
             detected_bg = detector.detect_background()

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -5,7 +5,7 @@ import json
 import logging
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Literal, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pytz
 from pydantic import Field, field_validator
@@ -103,7 +103,7 @@ class Settings(BaseSettings):
         default="custom",
         description="Plan type (pro, max5, max20, custom)",
     )
-    
+
     view: Literal["realtime", "daily", "monthly", "session"] = Field(
         default="realtime",
         description="View mode (realtime, daily, monthly, session)",
@@ -183,7 +183,7 @@ class Settings(BaseSettings):
                 f"Invalid plan: {v}. Must be one of: {', '.join(valid_plans)}"
             )
         return v
-    
+
     @field_validator("view", mode="before")
     @classmethod
     def validate_view(cls, v: Any) -> str:

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -5,22 +5,13 @@ by day and month, similar to ccusage's functionality.
 """
 
 import logging
-
 from collections import defaultdict
-from dataclasses import dataclass
-from dataclasses import field
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any
-from typing import Callable
-from typing import Dict
-from typing import List
-from typing import Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from claude_monitor.core.models import SessionBlock
-from claude_monitor.core.models import UsageEntry
-from claude_monitor.core.models import normalize_model_name
+from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
 from claude_monitor.utils.time_utils import TimezoneHandler
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -5,18 +5,30 @@ by day and month, similar to ccusage's functionality.
 """
 
 import logging
-from collections import defaultdict
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional
 
-from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
+from collections import defaultdict
+from dataclasses import dataclass
+from dataclasses import field
+from datetime import datetime
+from typing import Any
+from typing import Callable
+from typing import Dict
+from typing import List
+from typing import Optional
+
+from claude_monitor.core.models import SessionBlock
+from claude_monitor.core.models import UsageEntry
+from claude_monitor.core.models import normalize_model_name
 from claude_monitor.utils.time_utils import TimezoneHandler
 
+
 logger = logging.getLogger(__name__)
+
+
 @dataclass
 class AggregatedStats:
     """Statistics for aggregated usage data."""
+
     input_tokens: int = 0
     output_tokens: int = 0
     cache_creation_tokens: int = 0
@@ -43,13 +55,18 @@ class AggregatedStats:
             "cost": self.cost,
             "count": self.count,
         }
+
+
 @dataclass
 class AggregatedPeriod:
     """Aggregated data for a time period (day or month)."""
+
     period_key: str
     stats: AggregatedStats = field(default_factory=AggregatedStats)
     models_used: set = field(default_factory=set)
-    model_breakdowns: Dict[str, AggregatedStats] = field(default_factory=lambda: defaultdict(AggregatedStats))
+    model_breakdowns: Dict[str, AggregatedStats] = field(
+        default_factory=lambda: defaultdict(AggregatedStats)
+    )
 
     def add_entry(self, entry: UsageEntry) -> None:
         """Add an entry to this period's aggregate."""
@@ -74,16 +91,19 @@ class AggregatedPeriod:
             "total_cost": self.stats.cost,
             "models_used": sorted(list(self.models_used)),
             "model_breakdowns": {
-                model: stats.to_dict()
-                for model, stats in self.model_breakdowns.items()
+                model: stats.to_dict() for model, stats in self.model_breakdowns.items()
             },
             "entries_count": self.stats.count,
         }
         return result
+
+
 class UsageAggregator:
     """Aggregates usage data for daily and monthly reports."""
 
-    def __init__(self, data_path: str, aggregation_mode: str = "daily", timezone: str = "UTC"):
+    def __init__(
+        self, data_path: str, aggregation_mode: str = "daily", timezone: str = "UTC"
+    ):
         """Initialize the aggregator.
 
         Args:
@@ -144,7 +164,10 @@ class UsageAggregator:
         return result
 
     def aggregate_daily(
-        self, entries: List[UsageEntry], start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
+        self,
+        entries: List[UsageEntry],
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> List[Dict[str, Any]]:
         """Aggregate usage data by day.
 
@@ -165,7 +188,10 @@ class UsageAggregator:
         )
 
     def aggregate_monthly(
-        self, entries: List[UsageEntry], start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
+        self,
+        entries: List[UsageEntry],
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
     ) -> List[Dict[str, Any]]:
         """Aggregate usage data by month.
 
@@ -199,7 +225,9 @@ class UsageAggregator:
         """
         # Validate view type
         if view_type not in ["daily", "monthly"]:
-            raise ValueError(f"Invalid view type: {view_type}. Must be 'daily' or 'monthly'")
+            raise ValueError(
+                f"Invalid view type: {view_type}. Must be 'daily' or 'monthly'"
+            )
 
         # Extract all entries from blocks
         all_entries = []
@@ -276,4 +304,3 @@ class UsageAggregator:
             return self.aggregate_monthly(entries)
         else:
             raise ValueError(f"Invalid aggregation mode: {self.aggregation_mode}")
-

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -6,8 +6,8 @@ by day and month, similar to ccusage's functionality.
 
 import logging
 from collections import defaultdict
-from datetime import datetime
 from dataclasses import dataclass, field
+from datetime import datetime
 from typing import Any, Callable, Dict, List, Optional
 
 from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -1,0 +1,279 @@
+"""Data aggregator for daily and monthly statistics.
+
+This module provides functionality to aggregate Claude usage data
+by day and month, similar to ccusage's functionality.
+"""
+
+import logging
+from collections import defaultdict
+from datetime import datetime
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from dataclasses import dataclass, field
+
+from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
+from claude_monitor.utils.time_utils import TimezoneHandler
+
+logger = logging.getLogger(__name__)
+@dataclass
+class AggregatedStats:
+    """Statistics for aggregated usage data."""
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    cost: float = 0.0
+    count: int = 0
+
+    def add_entry(self, entry: UsageEntry) -> None:
+        """Add an entry's statistics to this aggregate."""
+        self.input_tokens += entry.input_tokens
+        self.output_tokens += entry.output_tokens
+        self.cache_creation_tokens += entry.cache_creation_tokens
+        self.cache_read_tokens += entry.cache_read_tokens
+        self.cost += entry.cost_usd
+        self.count += 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Convert to dictionary format."""
+        return {
+            "input_tokens": self.input_tokens,
+            "output_tokens": self.output_tokens,
+            "cache_creation_tokens": self.cache_creation_tokens,
+            "cache_read_tokens": self.cache_read_tokens,
+            "cost": self.cost,
+            "count": self.count,
+        }
+@dataclass
+class AggregatedPeriod:
+    """Aggregated data for a time period (day or month)."""
+    period_key: str
+    stats: AggregatedStats = field(default_factory=AggregatedStats)
+    models_used: set = field(default_factory=set)
+    model_breakdowns: Dict[str, AggregatedStats] = field(default_factory=lambda: defaultdict(AggregatedStats))
+
+    def add_entry(self, entry: UsageEntry) -> None:
+        """Add an entry to this period's aggregate."""
+        # Add to overall stats
+        self.stats.add_entry(entry)
+
+        # Track model
+        model = normalize_model_name(entry.model) if entry.model else "unknown"
+        self.models_used.add(model)
+
+        # Add to model-specific stats
+        self.model_breakdowns[model].add_entry(entry)
+
+    def to_dict(self, period_type: str) -> Dict[str, Any]:
+        """Convert to dictionary format for display."""
+        result = {
+            period_type: self.period_key,
+            "input_tokens": self.stats.input_tokens,
+            "output_tokens": self.stats.output_tokens,
+            "cache_creation_tokens": self.stats.cache_creation_tokens,
+            "cache_read_tokens": self.stats.cache_read_tokens,
+            "total_cost": self.stats.cost,
+            "models_used": sorted(list(self.models_used)),
+            "model_breakdowns": {
+                model: stats.to_dict()
+                for model, stats in self.model_breakdowns.items()
+            },
+            "entries_count": self.stats.count,
+        }
+        return result
+class UsageAggregator:
+    """Aggregates usage data for daily and monthly reports."""
+
+    def __init__(self, data_path: str, aggregation_mode: str = "daily", timezone: str = "UTC"):
+        """Initialize the aggregator.
+        
+        Args:
+            data_path: Path to the data directory
+            aggregation_mode: Mode of aggregation ('daily' or 'monthly')
+            timezone: Timezone string for date formatting
+        """
+        self.data_path = data_path
+        self.aggregation_mode = aggregation_mode
+        self.timezone = timezone
+        self.timezone_handler = TimezoneHandler()
+
+    def _aggregate_by_period(
+        self,
+        entries: List[UsageEntry],
+        period_key_func: Callable[[datetime], str],
+        period_type: str,
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Generic aggregation by time period.
+
+        Args:
+            entries: List of usage entries
+            period_key_func: Function to extract period key from timestamp
+            period_type: Type of period ('date' or 'month')
+            start_date: Optional start date filter
+            end_date: Optional end date filter
+
+        Returns:
+            List of aggregated data dictionaries
+        """
+        period_data: Dict[str, AggregatedPeriod] = {}
+
+        for entry in entries:
+            # Apply date filters
+            if start_date and entry.timestamp < start_date:
+                continue
+            if end_date and entry.timestamp > end_date:
+                continue
+
+            # Get period key
+            period_key = period_key_func(entry.timestamp)
+
+            # Get or create period aggregate
+            if period_key not in period_data:
+                period_data[period_key] = AggregatedPeriod(period_key)
+
+            # Add entry to period
+            period_data[period_key].add_entry(entry)
+
+        # Convert to list and sort
+        result = []
+        for period_key in sorted(period_data.keys()):
+            period = period_data[period_key]
+            result.append(period.to_dict(period_type))
+
+        return result
+
+    def aggregate_daily(
+        self, entries: List[UsageEntry], start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
+    ) -> List[Dict[str, Any]]:
+        """Aggregate usage data by day.
+
+        Args:
+            entries: List of usage entries
+            start_date: Optional start date filter
+            end_date: Optional end date filter
+
+        Returns:
+            List of daily aggregated data
+        """
+        return self._aggregate_by_period(
+            entries,
+            lambda timestamp: timestamp.strftime("%Y-%m-%d"),
+            "date",
+            start_date,
+            end_date,
+        )
+
+    def aggregate_monthly(
+        self, entries: List[UsageEntry], start_date: Optional[datetime] = None, end_date: Optional[datetime] = None
+    ) -> List[Dict[str, Any]]:
+        """Aggregate usage data by month.
+
+        Args:
+            entries: List of usage entries
+            start_date: Optional start date filter
+            end_date: Optional end date filter
+
+        Returns:
+            List of monthly aggregated data
+        """
+        return self._aggregate_by_period(
+            entries,
+            lambda timestamp: timestamp.strftime("%Y-%m"),
+            "month",
+            start_date,
+            end_date,
+        )
+
+    def aggregate_from_blocks(
+        self, blocks: List[SessionBlock], view_type: str = "daily"
+    ) -> List[Dict[str, Any]]:
+        """Aggregate data from session blocks.
+
+        Args:
+            blocks: List of session blocks
+            view_type: Type of aggregation ('daily' or 'monthly')
+
+        Returns:
+            List of aggregated data
+        """
+        # Validate view type
+        if view_type not in ["daily", "monthly"]:
+            raise ValueError(f"Invalid view type: {view_type}. Must be 'daily' or 'monthly'")
+
+        # Extract all entries from blocks
+        all_entries = []
+        for block in blocks:
+            if not block.is_gap:
+                all_entries.extend(block.entries)
+
+        # Aggregate based on view type
+        if view_type == "daily":
+            return self.aggregate_daily(all_entries)
+        else:
+            return self.aggregate_monthly(all_entries)
+
+    def calculate_totals(self, aggregated_data: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Calculate totals from aggregated data.
+
+        Args:
+            aggregated_data: List of aggregated daily or monthly data
+
+        Returns:
+            Dictionary with total statistics
+        """
+        total_stats = AggregatedStats()
+
+        for data in aggregated_data:
+            total_stats.input_tokens += data.get("input_tokens", 0)
+            total_stats.output_tokens += data.get("output_tokens", 0)
+            total_stats.cache_creation_tokens += data.get("cache_creation_tokens", 0)
+            total_stats.cache_read_tokens += data.get("cache_read_tokens", 0)
+            total_stats.cost += data.get("total_cost", 0.0)
+            total_stats.count += data.get("entries_count", 0)
+
+        return {
+            "input_tokens": total_stats.input_tokens,
+            "output_tokens": total_stats.output_tokens,
+            "cache_creation_tokens": total_stats.cache_creation_tokens,
+            "cache_read_tokens": total_stats.cache_read_tokens,
+            "total_tokens": (
+                total_stats.input_tokens
+                + total_stats.output_tokens
+                + total_stats.cache_creation_tokens
+                + total_stats.cache_read_tokens
+            ),
+            "total_cost": total_stats.cost,
+            "entries_count": total_stats.count,
+        }
+    
+    def aggregate(self) -> List[Dict[str, Any]]:
+        """Main aggregation method that reads data and returns aggregated results.
+        
+        Returns:
+            List of aggregated data based on aggregation_mode
+        """
+        from claude_monitor.data.reader import load_usage_entries
+        
+        logger.info(f"Starting aggregation in {self.aggregation_mode} mode")
+        
+        # Load usage entries
+        entries, _ = load_usage_entries(data_path=self.data_path)
+        
+        if not entries:
+            logger.warning("No usage entries found")
+            return []
+        
+        # Apply timezone to entries
+        for entry in entries:
+            if entry.timestamp.tzinfo is None:
+                entry.timestamp = self.timezone_handler.localize_datetime(entry.timestamp)
+        
+        # Aggregate based on mode
+        if self.aggregation_mode == "daily":
+            return self.aggregate_daily(entries)
+        elif self.aggregation_mode == "monthly":
+            return self.aggregate_monthly(entries)
+        else:
+            raise ValueError(f"Invalid aggregation mode: {self.aggregation_mode}")
+

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -7,8 +7,8 @@ by day and month, similar to ccusage's functionality.
 import logging
 from collections import defaultdict
 from datetime import datetime
-from typing import Any, Callable, Dict, List, Optional, Tuple
 from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, List, Optional
 
 from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
 from claude_monitor.utils.time_utils import TimezoneHandler

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -267,7 +267,7 @@ class UsageAggregator:
         # Apply timezone to entries
         for entry in entries:
             if entry.timestamp.tzinfo is None:
-                entry.timestamp = self.timezone_handler.localize_datetime(entry.timestamp)
+                entry.timestamp = self.timezone_handler.ensure_timezone(entry.timestamp)
         
         # Aggregate based on mode
         if self.aggregation_mode == "daily":

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -85,7 +85,7 @@ class UsageAggregator:
 
     def __init__(self, data_path: str, aggregation_mode: str = "daily", timezone: str = "UTC"):
         """Initialize the aggregator.
-        
+
         Args:
             data_path: Path to the data directory
             aggregation_mode: Mode of aggregation ('daily' or 'monthly')
@@ -246,29 +246,29 @@ class UsageAggregator:
             "total_cost": total_stats.cost,
             "entries_count": total_stats.count,
         }
-    
+
     def aggregate(self) -> List[Dict[str, Any]]:
         """Main aggregation method that reads data and returns aggregated results.
-        
+
         Returns:
             List of aggregated data based on aggregation_mode
         """
         from claude_monitor.data.reader import load_usage_entries
-        
+
         logger.info(f"Starting aggregation in {self.aggregation_mode} mode")
-        
+
         # Load usage entries
         entries, _ = load_usage_entries(data_path=self.data_path)
-        
+
         if not entries:
             logger.warning("No usage entries found")
             return []
-        
+
         # Apply timezone to entries
         for entry in entries:
             if entry.timestamp.tzinfo is None:
                 entry.timestamp = self.timezone_handler.ensure_timezone(entry.timestamp)
-        
+
         # Aggregate based on mode
         if self.aggregation_mode == "daily":
             return self.aggregate_daily(entries)

--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -5,16 +5,9 @@ import os
 import re
 import sys
 import threading
-
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Tuple
-from typing import Union
-
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 # Windows-compatible imports with graceful fallbacks
 try:

--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -664,10 +664,10 @@ _theme_manager: ThemeManager = ThemeManager()
 
 def get_theme(name: Optional[str] = None) -> Theme:
     """Get Rich theme by name or auto-detect.
-    
+
     Args:
         name: Theme name ('light', 'dark', 'classic') or None for auto-detection
-        
+
     Returns:
         Rich Theme object
     """

--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -662,6 +662,19 @@ def get_velocity_indicator(burn_rate: float) -> Dict[str, str]:
 _theme_manager: ThemeManager = ThemeManager()
 
 
+def get_theme(name: Optional[str] = None) -> Theme:
+    """Get Rich theme by name or auto-detect.
+    
+    Args:
+        name: Theme name ('light', 'dark', 'classic') or None for auto-detection
+        
+    Returns:
+        Rich Theme object
+    """
+    theme_config = _theme_manager.get_theme(name)
+    return theme_config.rich_theme
+
+
 def get_themed_console(force_theme: Optional[Union[str, bool]] = None) -> Console:
     """Get themed console - backward compatibility wrapper.
 

--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -5,9 +5,16 @@ import os
 import re
 import sys
 import threading
+
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Tuple
+from typing import Union
+
 
 # Windows-compatible imports with graceful fallbacks
 try:

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -5,7 +5,12 @@ in table format using Rich library.
 """
 
 import logging
-from typing import Any, Dict, List, Optional, Union
+
+from typing import Any
+from typing import Dict
+from typing import List
+from typing import Optional
+from typing import Union
 
 from rich.align import Align
 from rich.console import Console
@@ -14,9 +19,13 @@ from rich.table import Table
 from rich.text import Text
 
 # Removed theme import - using direct styles
-from claude_monitor.utils.formatting import format_currency, format_number
+from claude_monitor.utils.formatting import format_currency
+from claude_monitor.utils.formatting import format_number
+
 
 logger = logging.getLogger(__name__)
+
+
 class TableViewsController:
     """Controller for table-based views (daily, monthly)."""
 
@@ -37,7 +46,9 @@ class TableViewsController:
         self.table_header_style = "bold"
         self.border_style = "bright_blue"
 
-    def _create_base_table(self, title: str, period_column_name: str, period_column_width: int) -> Table:
+    def _create_base_table(
+        self, title: str, period_column_name: str, period_column_width: int
+    ) -> Table:
         """Create a base table with common structure.
 
         Args:
@@ -59,18 +70,30 @@ class TableViewsController:
         )
 
         # Add columns
-        table.add_column(period_column_name, style=self.key_style, width=period_column_width)
+        table.add_column(
+            period_column_name, style=self.key_style, width=period_column_width
+        )
         table.add_column("Models", style=self.value_style, width=20)
         table.add_column("Input", style=self.value_style, justify="right", width=12)
         table.add_column("Output", style=self.value_style, justify="right", width=12)
-        table.add_column("Cache Create", style=self.value_style, justify="right", width=12)
-        table.add_column("Cache Read", style=self.value_style, justify="right", width=12)
-        table.add_column("Total Tokens", style=self.accent_style, justify="right", width=12)
-        table.add_column("Cost (USD)", style=self.success_style, justify="right", width=10)
+        table.add_column(
+            "Cache Create", style=self.value_style, justify="right", width=12
+        )
+        table.add_column(
+            "Cache Read", style=self.value_style, justify="right", width=12
+        )
+        table.add_column(
+            "Total Tokens", style=self.accent_style, justify="right", width=12
+        )
+        table.add_column(
+            "Cost (USD)", style=self.success_style, justify="right", width=10
+        )
 
         return table
 
-    def _add_data_rows(self, table: Table, data_list: List[Dict[str, Any]], period_key: str) -> None:
+    def _add_data_rows(
+        self, table: Table, data_list: List[Dict[str, Any]], period_key: str
+    ) -> None:
         """Add data rows to the table.
 
         Args:
@@ -114,14 +137,19 @@ class TableViewsController:
             "",
             Text(format_number(totals["input_tokens"]), style=self.accent_style),
             Text(format_number(totals["output_tokens"]), style=self.accent_style),
-            Text(format_number(totals["cache_creation_tokens"]), style=self.accent_style),
+            Text(
+                format_number(totals["cache_creation_tokens"]), style=self.accent_style
+            ),
             Text(format_number(totals["cache_read_tokens"]), style=self.accent_style),
             Text(format_number(totals["total_tokens"]), style=self.accent_style),
             Text(format_currency(totals["total_cost"]), style=self.success_style),
         )
 
     def create_daily_table(
-        self, daily_data: List[Dict[str, Any]], totals: Dict[str, Any], timezone: str = "UTC"
+        self,
+        daily_data: List[Dict[str, Any]],
+        totals: Dict[str, Any],
+        timezone: str = "UTC",
     ) -> Table:
         """Create a daily statistics table.
 
@@ -137,7 +165,7 @@ class TableViewsController:
         table = self._create_base_table(
             title=f"Claude Code Token Usage Report - Daily ({timezone})",
             period_column_name="Date",
-            period_column_width=12
+            period_column_width=12,
         )
 
         # Add data rows
@@ -149,7 +177,10 @@ class TableViewsController:
         return table
 
     def create_monthly_table(
-        self, monthly_data: List[Dict[str, Any]], totals: Dict[str, Any], timezone: str = "UTC"
+        self,
+        monthly_data: List[Dict[str, Any]],
+        totals: Dict[str, Any],
+        timezone: str = "UTC",
     ) -> Table:
         """Create a monthly statistics table.
 
@@ -165,7 +196,7 @@ class TableViewsController:
         table = self._create_base_table(
             title=f"Claude Code Token Usage Report - Monthly ({timezone})",
             period_column_name="Month",
-            period_column_width=10
+            period_column_width=10,
         )
 
         # Add data rows
@@ -176,7 +207,9 @@ class TableViewsController:
 
         return table
 
-    def create_summary_panel(self, view_type: str, totals: Dict[str, Any], period: str) -> Panel:
+    def create_summary_panel(
+        self, view_type: str, totals: Dict[str, Any], period: str
+    ) -> Panel:
         """Create a summary panel for the table view.
 
         Args:
@@ -323,8 +356,10 @@ class TableViewsController:
             "cache_creation_tokens": sum(d["cache_creation_tokens"] for d in data),
             "cache_read_tokens": sum(d["cache_read_tokens"] for d in data),
             "total_tokens": sum(
-                d["input_tokens"] + d["output_tokens"] +
-                d["cache_creation_tokens"] + d["cache_read_tokens"]
+                d["input_tokens"]
+                + d["output_tokens"]
+                + d["cache_creation_tokens"]
+                + d["cache_read_tokens"]
                 for d in data
             ),
             "total_cost": sum(d["total_cost"] for d in data),
@@ -350,7 +385,7 @@ class TableViewsController:
             console.print(table)
         else:
             from rich import print as rprint
+
             rprint(summary_panel)
             rprint()
             rprint(table)
-

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -323,8 +323,8 @@ class TableViewsController:
             "cache_creation_tokens": sum(d["cache_creation_tokens"] for d in data),
             "cache_read_tokens": sum(d["cache_read_tokens"] for d in data),
             "total_tokens": sum(
-                d["input_tokens"] + d["output_tokens"] + 
-                d["cache_creation_tokens"] + d["cache_read_tokens"] 
+                d["input_tokens"] + d["output_tokens"] +
+                d["cache_creation_tokens"] + d["cache_read_tokens"]
                 for d in data
             ),
             "total_cost": sum(d["total_cost"] for d in data),

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -230,8 +230,17 @@ class TableViewsController:
         # Create bullet list
         if len(models) == 1:
             return models[0]
-        else:
+        elif len(models) <= 5:
             return "\n".join([f"• {model}" for model in models])
+        else:
+            # Show first 3 models and count of remaining
+            displayed_models = models[:3]
+            remaining_count = len(models) - 3
+            
+            formatted_list = [f"• {model}" for model in displayed_models]
+            formatted_list.append(f"• ... and {remaining_count} more")
+            
+            return "\n".join(formatted_list)
 
     def create_no_data_display(self, view_type: str) -> Panel:
         """Create a display for when no data is available.
@@ -326,7 +335,7 @@ class TableViewsController:
                 for d in data
             ),
             "total_cost": sum(d["total_cost"] for d in data),
-            "entries_count": len(data),
+            "entries_count": sum(d.get("entries_count", 0) for d in data),
         }
         
         # Determine period for summary

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -22,7 +22,7 @@ class TableViewsController:
 
     def __init__(self, console: Optional[Console] = None):
         """Initialize the table views controller.
-        
+
         Args:
             console: Optional Console instance for rich output
         """
@@ -236,10 +236,10 @@ class TableViewsController:
             # Show first 3 models and count of remaining
             displayed_models = models[:3]
             remaining_count = len(models) - 3
-            
+
             formatted_list = [f"• {model}" for model in displayed_models]
             formatted_list.append(f"• ... and {remaining_count} more")
-            
+
             return "\n".join(formatted_list)
 
     def create_no_data_display(self, view_type: str) -> Panel:
@@ -295,7 +295,7 @@ class TableViewsController:
             return self.create_monthly_table(aggregate_data, totals, timezone)
         else:
             raise ValueError(f"Invalid view type: {view_type}")
-    
+
     def display_aggregated_view(
         self,
         data: List[Dict[str, Any]],
@@ -306,7 +306,7 @@ class TableViewsController:
         console: Optional[Console] = None,
     ) -> None:
         """Display aggregated view with table and summary.
-        
+
         Args:
             data: Aggregated data
             view_mode: View type ('daily' or 'monthly')
@@ -322,7 +322,7 @@ class TableViewsController:
             else:
                 print(no_data_display)
             return
-            
+
         # Calculate totals
         totals = {
             "input_tokens": sum(d["input_tokens"] for d in data),
@@ -337,19 +337,19 @@ class TableViewsController:
             "total_cost": sum(d["total_cost"] for d in data),
             "entries_count": sum(d.get("entries_count", 0) for d in data),
         }
-        
+
         # Determine period for summary
         if view_mode == "daily":
             period = f"{data[0]['date']} to {data[-1]['date']}" if data else "No data"
         else:  # monthly
             period = f"{data[0]['month']} to {data[-1]['month']}" if data else "No data"
-        
+
         # Create and display summary panel
         summary_panel = self.create_summary_panel(view_mode, totals, period)
-        
+
         # Create and display table
         table = self.create_aggregate_table(data, totals, view_mode, timezone)
-        
+
         # Display using console if provided
         if console:
             console.print(summary_panel)

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -1,0 +1,354 @@
+"""Table views for daily and monthly statistics display.
+
+This module provides UI components for displaying aggregated usage data
+in table format using Rich library.
+"""
+
+import logging
+from typing import Any, Dict, List, Optional, Union
+
+from rich.align import Align
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+from rich.text import Text
+
+# Removed theme import - using direct styles
+from claude_monitor.utils.formatting import format_currency, format_number
+
+logger = logging.getLogger(__name__)
+class TableViewsController:
+    """Controller for table-based views (daily, monthly)."""
+
+    def __init__(self, console: Optional[Console] = None):
+        """Initialize the table views controller.
+        
+        Args:
+            console: Optional Console instance for rich output
+        """
+        self.console = console
+        # Define simple styles
+        self.key_style = "cyan"
+        self.value_style = "white"
+        self.accent_style = "yellow"
+        self.success_style = "green"
+        self.warning_style = "yellow"
+        self.header_style = "bold cyan"
+        self.table_header_style = "bold"
+        self.border_style = "bright_blue"
+
+    def create_daily_table(
+        self, daily_data: List[Dict[str, Any]], totals: Dict[str, Any], timezone: str = "UTC"
+    ) -> Table:
+        """Create a daily statistics table.
+
+        Args:
+            daily_data: List of daily aggregated data
+            totals: Total statistics
+            timezone: Timezone for display
+
+        Returns:
+            Rich Table object
+        """
+        # Create table with title
+        table = Table(
+            title=f"Claude Code Token Usage Report - Daily ({timezone})",
+            title_style="bold cyan",
+            show_header=True,
+            header_style="bold",
+            border_style="bright_blue",
+            expand=True,
+            show_lines=True,
+        )
+
+        # Add columns
+        table.add_column("Date", style=self.key_style, width=12)
+        table.add_column("Models", style=self.value_style, width=20)
+        table.add_column("Input", style=self.value_style, justify="right", width=12)
+        table.add_column("Output", style=self.value_style, justify="right", width=12)
+        table.add_column("Cache Create", style=self.value_style, justify="right", width=12)
+        table.add_column("Cache Read", style=self.value_style, justify="right", width=12)
+        table.add_column("Total Tokens", style=self.accent_style, justify="right", width=12)
+        table.add_column("Cost (USD)", style=self.success_style, justify="right", width=10)
+
+        # Add data rows
+        for data in daily_data:
+            models_text = self._format_models(data["models_used"])
+            total_tokens = (
+                data["input_tokens"]
+                + data["output_tokens"]
+                + data["cache_creation_tokens"]
+                + data["cache_read_tokens"]
+            )
+
+            table.add_row(
+                data["date"],
+                models_text,
+                format_number(data["input_tokens"]),
+                format_number(data["output_tokens"]),
+                format_number(data["cache_creation_tokens"]),
+                format_number(data["cache_read_tokens"]),
+                format_number(total_tokens),
+                format_currency(data["total_cost"]),
+            )
+
+        # Add separator
+        table.add_row("", "", "", "", "", "", "", "")
+
+        # Add totals row
+        table.add_row(
+            Text("Total", style=self.accent_style),
+            "",
+            Text(format_number(totals["input_tokens"]), style=self.accent_style),
+            Text(format_number(totals["output_tokens"]), style=self.accent_style),
+            Text(format_number(totals["cache_creation_tokens"]), style=self.accent_style),
+            Text(format_number(totals["cache_read_tokens"]), style=self.accent_style),
+            Text(format_number(totals["total_tokens"]), style=self.accent_style),
+            Text(format_currency(totals["total_cost"]), style=self.success_style),
+        )
+
+        return table
+
+    def create_monthly_table(
+        self, monthly_data: List[Dict[str, Any]], totals: Dict[str, Any], timezone: str = "UTC"
+    ) -> Table:
+        """Create a monthly statistics table.
+
+        Args:
+            monthly_data: List of monthly aggregated data
+            totals: Total statistics
+            timezone: Timezone for display
+
+        Returns:
+            Rich Table object
+        """
+        # Create table with title
+        table = Table(
+            title=f"Claude Code Token Usage Report - Monthly ({timezone})",
+            title_style="bold cyan",
+            show_header=True,
+            header_style="bold",
+            border_style="bright_blue",
+            expand=True,
+            show_lines=True,
+        )
+
+        # Add columns
+        table.add_column("Month", style=self.key_style, width=10)
+        table.add_column("Models", style=self.value_style, width=20)
+        table.add_column("Input", style=self.value_style, justify="right", width=12)
+        table.add_column("Output", style=self.value_style, justify="right", width=12)
+        table.add_column("Cache Create", style=self.value_style, justify="right", width=12)
+        table.add_column("Cache Read", style=self.value_style, justify="right", width=12)
+        table.add_column("Total Tokens", style=self.accent_style, justify="right", width=12)
+        table.add_column("Cost (USD)", style=self.success_style, justify="right", width=10)
+
+        # Add data rows
+        for data in monthly_data:
+            models_text = self._format_models(data["models_used"])
+            total_tokens = (
+                data["input_tokens"]
+                + data["output_tokens"]
+                + data["cache_creation_tokens"]
+                + data["cache_read_tokens"]
+            )
+
+            table.add_row(
+                data["month"],
+                models_text,
+                format_number(data["input_tokens"]),
+                format_number(data["output_tokens"]),
+                format_number(data["cache_creation_tokens"]),
+                format_number(data["cache_read_tokens"]),
+                format_number(total_tokens),
+                format_currency(data["total_cost"]),
+            )
+
+        # Add separator
+        table.add_row("", "", "", "", "", "", "", "")
+
+        # Add totals row
+        table.add_row(
+            Text("Total", style=self.accent_style),
+            "",
+            Text(format_number(totals["input_tokens"]), style=self.accent_style),
+            Text(format_number(totals["output_tokens"]), style=self.accent_style),
+            Text(format_number(totals["cache_creation_tokens"]), style=self.accent_style),
+            Text(format_number(totals["cache_read_tokens"]), style=self.accent_style),
+            Text(format_number(totals["total_tokens"]), style=self.accent_style),
+            Text(format_currency(totals["total_cost"]), style=self.success_style),
+        )
+
+        return table
+
+    def create_summary_panel(self, view_type: str, totals: Dict[str, Any], period: str) -> Panel:
+        """Create a summary panel for the table view.
+
+        Args:
+            view_type: Type of view ('daily' or 'monthly')
+            totals: Total statistics
+            period: Period description
+
+        Returns:
+            Rich Panel object
+        """
+        # Create summary text
+        summary_lines = [
+            f"📊 {view_type.capitalize()} Usage Summary - {period}",
+            "",
+            f"Total Tokens: {format_number(totals['total_tokens'])}",
+            f"Total Cost: {format_currency(totals['total_cost'])}",
+            f"Entries: {format_number(totals['entries_count'])}",
+        ]
+
+        summary_text = Text("\n".join(summary_lines), style=self.value_style)
+
+        # Create panel
+        panel = Panel(
+            Align.center(summary_text),
+            title="Summary",
+            title_align="center",
+            border_style=self.border_style,
+            expand=False,
+            padding=(1, 2),
+        )
+
+        return panel
+
+    def _format_models(self, models: List[str]) -> str:
+        """Format model names for display.
+
+        Args:
+            models: List of model names
+
+        Returns:
+            Formatted string of model names
+        """
+        if not models:
+            return "No models"
+
+        # Create bullet list
+        if len(models) == 1:
+            return models[0]
+        else:
+            return "\n".join([f"• {model}" for model in models])
+
+    def create_no_data_display(self, view_type: str) -> Panel:
+        """Create a display for when no data is available.
+
+        Args:
+            view_type: Type of view ('daily' or 'monthly')
+
+        Returns:
+            Rich Panel object
+        """
+        message = Text(
+            f"No {view_type} data found.\n\nTry using Claude Code to generate some usage data.",
+            style=self.warning_style,
+            justify="center",
+        )
+
+        panel = Panel(
+            Align.center(message, vertical="middle"),
+            title=f"No {view_type.capitalize()} Data",
+            title_align="center",
+            border_style=self.warning_style,
+            expand=True,
+            height=10,
+        )
+
+        return panel
+
+    def create_aggregate_table(
+        self,
+        aggregate_data: Union[List[Dict[str, Any]], List[Dict[str, Any]]],
+        totals: Dict[str, Any],
+        view_type: str,
+        timezone: str = "UTC",
+    ) -> Table:
+        """Create a table for either daily or monthly aggregated data.
+
+        Args:
+            aggregate_data: List of aggregated data (daily or monthly)
+            totals: Total statistics
+            view_type: Type of view ('daily' or 'monthly')
+            timezone: Timezone for display
+
+        Returns:
+            Rich Table object
+
+        Raises:
+            ValueError: If view_type is not 'daily' or 'monthly'
+        """
+        if view_type == "daily":
+            return self.create_daily_table(aggregate_data, totals, timezone)
+        elif view_type == "monthly":
+            return self.create_monthly_table(aggregate_data, totals, timezone)
+        else:
+            raise ValueError(f"Invalid view type: {view_type}")
+    
+    def display_aggregated_view(
+        self,
+        data: List[Dict[str, Any]],
+        view_mode: str,
+        timezone: str,
+        plan: str,
+        token_limit: int,
+        console: Optional[Console] = None,
+    ) -> None:
+        """Display aggregated view with table and summary.
+        
+        Args:
+            data: Aggregated data
+            view_mode: View type ('daily' or 'monthly')
+            timezone: Timezone string
+            plan: Plan type
+            token_limit: Token limit for the plan
+            console: Optional Console instance
+        """
+        if not data:
+            no_data_display = self.create_no_data_display(view_mode)
+            if console:
+                console.print(no_data_display)
+            else:
+                print(no_data_display)
+            return
+            
+        # Calculate totals
+        totals = {
+            "input_tokens": sum(d["input_tokens"] for d in data),
+            "output_tokens": sum(d["output_tokens"] for d in data),
+            "cache_creation_tokens": sum(d["cache_creation_tokens"] for d in data),
+            "cache_read_tokens": sum(d["cache_read_tokens"] for d in data),
+            "total_tokens": sum(
+                d["input_tokens"] + d["output_tokens"] + 
+                d["cache_creation_tokens"] + d["cache_read_tokens"] 
+                for d in data
+            ),
+            "total_cost": sum(d["total_cost"] for d in data),
+            "entries_count": len(data),
+        }
+        
+        # Determine period for summary
+        if view_mode == "daily":
+            period = f"{data[0]['date']} to {data[-1]['date']}" if data else "No data"
+        else:  # monthly
+            period = f"{data[0]['month']} to {data[-1]['month']}" if data else "No data"
+        
+        # Create and display summary panel
+        summary_panel = self.create_summary_panel(view_mode, totals, period)
+        
+        # Create and display table
+        table = self.create_aggregate_table(data, totals, view_mode, timezone)
+        
+        # Display using console if provided
+        if console:
+            console.print(summary_panel)
+            console.print()
+            console.print(table)
+        else:
+            from rich import print as rprint
+            rprint(summary_panel)
+            rprint()
+            rprint(table)
+

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -5,12 +5,7 @@ in table format using Rich library.
 """
 
 import logging
-
-from typing import Any
-from typing import Dict
-from typing import List
-from typing import Optional
-from typing import Union
+from typing import Any, Dict, List, Optional, Union
 
 from rich.align import Align
 from rich.console import Console
@@ -19,9 +14,7 @@ from rich.table import Table
 from rich.text import Text
 
 # Removed theme import - using direct styles
-from claude_monitor.utils.formatting import format_currency
-from claude_monitor.utils.formatting import format_number
-
+from claude_monitor.utils.formatting import format_currency, format_number
 
 logger = logging.getLogger(__name__)
 

--- a/src/claude_monitor/utils/formatting.py
+++ b/src/claude_monitor/utils/formatting.py
@@ -15,11 +15,11 @@ logger = logging.getLogger(__name__)
 
 def format_number(value: Union[int, float], decimals: int = 0) -> str:
     """Format number with thousands separator.
-    
+
     Args:
         value: Number to format
         decimals: Number of decimal places (default: 0)
-        
+
     Returns:
         Formatted number string with thousands separator
     """

--- a/src/claude_monitor/utils/formatting.py
+++ b/src/claude_monitor/utils/formatting.py
@@ -5,12 +5,27 @@ This module provides formatting functions for currency, time, and display output
 
 import logging
 from datetime import datetime
-from typing import Any, Optional
+from typing import Any, Optional, Union
 
 from claude_monitor.utils.time_utils import format_display_time as _format_display_time
 from claude_monitor.utils.time_utils import get_time_format_preference
 
 logger = logging.getLogger(__name__)
+
+
+def format_number(value: Union[int, float], decimals: int = 0) -> str:
+    """Format number with thousands separator.
+    
+    Args:
+        value: Number to format
+        decimals: Number of decimal places (default: 0)
+        
+    Returns:
+        Formatted number string with thousands separator
+    """
+    if decimals > 0:
+        return f"{value:,.{decimals}f}"
+    return f"{int(value):,}"
 
 
 def format_currency(amount: float, currency: str = "USD") -> str:

--- a/src/claude_monitor/utils/formatting.py
+++ b/src/claude_monitor/utils/formatting.py
@@ -4,15 +4,11 @@ This module provides formatting functions for currency, time, and display output
 """
 
 import logging
-
 from datetime import datetime
-from typing import Any
-from typing import Optional
-from typing import Union
+from typing import Any, Optional, Union
 
 from claude_monitor.utils.time_utils import format_display_time as _format_display_time
 from claude_monitor.utils.time_utils import get_time_format_preference
-
 
 logger = logging.getLogger(__name__)
 

--- a/src/claude_monitor/utils/formatting.py
+++ b/src/claude_monitor/utils/formatting.py
@@ -4,11 +4,15 @@ This module provides formatting functions for currency, time, and display output
 """
 
 import logging
+
 from datetime import datetime
-from typing import Any, Optional, Union
+from typing import Any
+from typing import Optional
+from typing import Union
 
 from claude_monitor.utils.time_utils import format_display_time as _format_display_time
 from claude_monitor.utils.time_utils import get_time_format_preference
+
 
 logger = logging.getLogger(__name__)
 

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -1,0 +1,601 @@
+"""Tests for data aggregator module."""
+
+from datetime import datetime, timezone, timedelta
+from typing import List
+from unittest.mock import Mock, patch
+
+import pytest
+
+from claude_monitor.core.models import UsageEntry
+from claude_monitor.data.aggregator import (
+    AggregatedStats,
+    AggregatedPeriod,
+    UsageAggregator,
+)
+
+
+class TestAggregatedStats:
+    """Test cases for AggregatedStats dataclass."""
+
+    def test_init_default_values(self) -> None:
+        """Test default initialization of AggregatedStats."""
+        stats = AggregatedStats()
+        assert stats.input_tokens == 0
+        assert stats.output_tokens == 0
+        assert stats.cache_creation_tokens == 0
+        assert stats.cache_read_tokens == 0
+        assert stats.cost == 0.0
+        assert stats.count == 0
+
+    def test_add_entry_single(self, sample_usage_entry: UsageEntry) -> None:
+        """Test adding a single entry to stats."""
+        stats = AggregatedStats()
+        stats.add_entry(sample_usage_entry)
+        
+        assert stats.input_tokens == 100
+        assert stats.output_tokens == 50
+        assert stats.cache_creation_tokens == 10
+        assert stats.cache_read_tokens == 5
+        assert stats.cost == 0.001
+        assert stats.count == 1
+
+    def test_add_entry_multiple(self) -> None:
+        """Test adding multiple entries to stats."""
+        stats = AggregatedStats()
+        
+        # Create multiple entries
+        entry1 = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=10,
+            cache_read_tokens=5,
+            cost_usd=0.001,
+            model="claude-3-haiku",
+            message_id="msg_1",
+            request_id="req_1",
+        )
+        
+        entry2 = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc),
+            input_tokens=200,
+            output_tokens=100,
+            cache_creation_tokens=20,
+            cache_read_tokens=10,
+            cost_usd=0.002,
+            model="claude-3-sonnet",
+            message_id="msg_2",
+            request_id="req_2",
+        )
+        
+        stats.add_entry(entry1)
+        stats.add_entry(entry2)
+        
+        assert stats.input_tokens == 300
+        assert stats.output_tokens == 150
+        assert stats.cache_creation_tokens == 30
+        assert stats.cache_read_tokens == 15
+        assert stats.cost == 0.003
+        assert stats.count == 2
+
+    def test_to_dict(self) -> None:
+        """Test converting AggregatedStats to dictionary."""
+        stats = AggregatedStats(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=100,
+            cache_read_tokens=50,
+            cost=0.05,
+            count=10
+        )
+        
+        result = stats.to_dict()
+        
+        assert result == {
+            "input_tokens": 1000,
+            "output_tokens": 500,
+            "cache_creation_tokens": 100,
+            "cache_read_tokens": 50,
+            "cost": 0.05,
+            "count": 10,
+        }
+
+
+class TestAggregatedPeriod:
+    """Test cases for AggregatedPeriod dataclass."""
+
+    def test_init_default_values(self) -> None:
+        """Test default initialization of AggregatedPeriod."""
+        period = AggregatedPeriod(period_key="2024-01-01")
+        
+        assert period.period_key == "2024-01-01"
+        assert isinstance(period.stats, AggregatedStats)
+        assert period.stats.count == 0
+        assert len(period.models_used) == 0
+        assert len(period.model_breakdowns) == 0
+
+    def test_add_entry_single(self, sample_usage_entry: UsageEntry) -> None:
+        """Test adding a single entry to period."""
+        period = AggregatedPeriod(period_key="2024-01-01")
+        period.add_entry(sample_usage_entry)
+        
+        # Check overall stats
+        assert period.stats.input_tokens == 100
+        assert period.stats.output_tokens == 50
+        assert period.stats.cost == 0.001
+        assert period.stats.count == 1
+        
+        # Check models tracking
+        assert "claude-3-haiku" in period.models_used
+        assert len(period.models_used) == 1
+        
+        # Check model breakdown
+        assert "claude-3-haiku" in period.model_breakdowns
+        assert period.model_breakdowns["claude-3-haiku"].input_tokens == 100
+
+    def test_add_entry_multiple_models(self) -> None:
+        """Test adding entries with different models."""
+        period = AggregatedPeriod(period_key="2024-01-01")
+        
+        # Add entries with different models
+        entry1 = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.001,
+            model="claude-3-haiku",
+            message_id="msg_1",
+            request_id="req_1",
+        )
+        
+        entry2 = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc),
+            input_tokens=200,
+            output_tokens=100,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.002,
+            model="claude-3-sonnet",
+            message_id="msg_2",
+            request_id="req_2",
+        )
+        
+        entry3 = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 14, 0, tzinfo=timezone.utc),
+            input_tokens=150,
+            output_tokens=75,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.0015,
+            model="claude-3-haiku",
+            message_id="msg_3",
+            request_id="req_3",
+        )
+        
+        period.add_entry(entry1)
+        period.add_entry(entry2)
+        period.add_entry(entry3)
+        
+        # Check overall stats
+        assert period.stats.input_tokens == 450
+        assert period.stats.output_tokens == 225
+        assert abs(period.stats.cost - 0.0045) < 0.0000001  # Handle floating point precision
+        assert period.stats.count == 3
+        
+        # Check models
+        assert len(period.models_used) == 2
+        assert "claude-3-haiku" in period.models_used
+        assert "claude-3-sonnet" in period.models_used
+        
+        # Check model breakdowns
+        assert period.model_breakdowns["claude-3-haiku"].input_tokens == 250
+        assert period.model_breakdowns["claude-3-haiku"].count == 2
+        assert period.model_breakdowns["claude-3-sonnet"].input_tokens == 200
+        assert period.model_breakdowns["claude-3-sonnet"].count == 1
+
+    def test_add_entry_with_unknown_model(self) -> None:
+        """Test adding entry with None or empty model."""
+        period = AggregatedPeriod(period_key="2024-01-01")
+        
+        entry = UsageEntry(
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            input_tokens=100,
+            output_tokens=50,
+            cache_creation_tokens=0,
+            cache_read_tokens=0,
+            cost_usd=0.001,
+            model=None,
+            message_id="msg_1",
+            request_id="req_1",
+        )
+        
+        period.add_entry(entry)
+        
+        assert "unknown" in period.models_used
+        assert "unknown" in period.model_breakdowns
+
+    def test_to_dict_daily(self) -> None:
+        """Test converting AggregatedPeriod to dictionary for daily view."""
+        period = AggregatedPeriod(period_key="2024-01-01")
+        period.stats = AggregatedStats(
+            input_tokens=1000,
+            output_tokens=500,
+            cache_creation_tokens=100,
+            cache_read_tokens=50,
+            cost=0.05,
+            count=10
+        )
+        period.models_used = {"claude-3-haiku", "claude-3-sonnet"}
+        period.model_breakdowns["claude-3-haiku"] = AggregatedStats(
+            input_tokens=600,
+            output_tokens=300,
+            cache_creation_tokens=60,
+            cache_read_tokens=30,
+            cost=0.03,
+            count=6
+        )
+        period.model_breakdowns["claude-3-sonnet"] = AggregatedStats(
+            input_tokens=400,
+            output_tokens=200,
+            cache_creation_tokens=40,
+            cache_read_tokens=20,
+            cost=0.02,
+            count=4
+        )
+        
+        result = period.to_dict("date")
+        
+        assert result["date"] == "2024-01-01"
+        assert result["input_tokens"] == 1000
+        assert result["output_tokens"] == 500
+        assert result["cache_creation_tokens"] == 100
+        assert result["cache_read_tokens"] == 50
+        assert result["total_cost"] == 0.05
+        assert result["entries_count"] == 10
+        assert set(result["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
+        assert "claude-3-haiku" in result["model_breakdowns"]
+        assert result["model_breakdowns"]["claude-3-haiku"]["input_tokens"] == 600
+
+    def test_to_dict_monthly(self) -> None:
+        """Test converting AggregatedPeriod to dictionary for monthly view."""
+        period = AggregatedPeriod(period_key="2024-01")
+        period.stats = AggregatedStats(
+            input_tokens=10000,
+            output_tokens=5000,
+            cache_creation_tokens=1000,
+            cache_read_tokens=500,
+            cost=0.5,
+            count=100
+        )
+        period.models_used = {"claude-3-haiku"}
+        
+        result = period.to_dict("month")
+        
+        assert result["month"] == "2024-01"
+        assert result["input_tokens"] == 10000
+        assert result["total_cost"] == 0.5
+
+
+class TestUsageAggregator:
+    """Test cases for UsageAggregator class."""
+
+    @pytest.fixture
+    def aggregator(self) -> UsageAggregator:
+        """Create a UsageAggregator instance."""
+        return UsageAggregator()
+
+    @pytest.fixture
+    def sample_entries(self) -> List[UsageEntry]:
+        """Create sample usage entries spanning multiple days and months."""
+        entries = []
+        
+        # January 2024 entries
+        for day in [1, 1, 2, 2, 15, 15, 31]:
+            for hour in [10, 14]:
+                entry = UsageEntry(
+                    timestamp=datetime(2024, 1, day, hour, 0, tzinfo=timezone.utc),
+                    input_tokens=100,
+                    output_tokens=50,
+                    cache_creation_tokens=10,
+                    cache_read_tokens=5,
+                    cost_usd=0.001,
+                    model="claude-3-haiku" if hour == 10 else "claude-3-sonnet",
+                    message_id=f"msg_{day}_{hour}",
+                    request_id=f"req_{day}_{hour}",
+                )
+                entries.append(entry)
+        
+        # February 2024 entries
+        for day in [1, 15, 29]:
+            entry = UsageEntry(
+                timestamp=datetime(2024, 2, day, 12, 0, tzinfo=timezone.utc),
+                input_tokens=200,
+                output_tokens=100,
+                cache_creation_tokens=20,
+                cache_read_tokens=10,
+                cost_usd=0.002,
+                model="claude-3-opus",
+                message_id=f"msg_feb_{day}",
+                request_id=f"req_feb_{day}",
+            )
+            entries.append(entry)
+        
+        return entries
+
+    def test_aggregate_daily_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test basic daily aggregation."""
+        result = aggregator.aggregate_daily(sample_entries)
+        
+        # Should have entries for each unique day
+        assert len(result) == 7  # Days: Jan 1, 2, 15, 31, Feb 1, 15, 29
+        
+        # Check first day (Jan 1 - 4 entries: 2 at 10AM, 2 at 2PM)
+        jan1 = result[0]
+        assert jan1["date"] == "2024-01-01"
+        assert jan1["input_tokens"] == 400  # 4 entries * 100
+        assert jan1["output_tokens"] == 200  # 4 entries * 50
+        assert jan1["total_cost"] == 0.004  # 4 entries * 0.001
+        assert jan1["entries_count"] == 4
+        assert set(jan1["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
+
+    def test_aggregate_daily_with_date_filter(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test daily aggregation with date filters."""
+        start_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
+        end_date = datetime(2024, 1, 31, 23, 59, 59, tzinfo=timezone.utc)  # Include the whole day
+        
+        result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
+        
+        # Should have Jan 15 and Jan 31 (entries on those days are within the filter)
+        assert len(result) == 2
+        assert result[0]["date"] == "2024-01-15"
+        assert result[1]["date"] == "2024-01-31"
+
+    def test_aggregate_monthly_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test basic monthly aggregation."""
+        result = aggregator.aggregate_monthly(sample_entries)
+        
+        # Should have 2 months
+        assert len(result) == 2
+        
+        # Check January
+        jan = result[0]
+        assert jan["month"] == "2024-01"
+        assert jan["input_tokens"] == 1400  # 14 entries * 100
+        assert jan["output_tokens"] == 700   # 14 entries * 50
+        assert abs(jan["total_cost"] - 0.014) < 0.0000001  # Handle floating point precision
+        assert jan["entries_count"] == 14
+        assert set(jan["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
+        
+        # Check February
+        feb = result[1]
+        assert feb["month"] == "2024-02"
+        assert feb["input_tokens"] == 600   # 3 entries * 200
+        assert feb["output_tokens"] == 300  # 3 entries * 100
+        assert feb["total_cost"] == 0.006  # 3 entries * 0.002
+        assert feb["entries_count"] == 3
+        assert feb["models_used"] == ["claude-3-opus"]
+
+    def test_aggregate_monthly_with_date_filter(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test monthly aggregation with date filters."""
+        start_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
+        
+        result = aggregator.aggregate_monthly(sample_entries, start_date)
+        
+        # Should only have February
+        assert len(result) == 1
+        assert result[0]["month"] == "2024-02"
+
+    def test_aggregate_from_blocks_daily(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test aggregating from session blocks for daily view."""
+        # Create mock session blocks
+        from claude_monitor.core.models import SessionBlock
+        
+        block1 = SessionBlock(
+            id="block1",
+            start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
+            end_time=datetime(2024, 1, 1, 15, 0, tzinfo=timezone.utc),
+            entries=sample_entries[:5],
+            is_gap=False
+        )
+        
+        block2 = SessionBlock(
+            id="block2",
+            start_time=datetime(2024, 1, 2, 10, 0, tzinfo=timezone.utc),
+            end_time=datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc),
+            entries=sample_entries[5:10],
+            is_gap=False
+        )
+        
+        # Gap block should be ignored
+        gap_block = SessionBlock(
+            id="gap",
+            start_time=datetime(2024, 1, 3, 10, 0, tzinfo=timezone.utc),
+            end_time=datetime(2024, 1, 3, 15, 0, tzinfo=timezone.utc),
+            entries=[],
+            is_gap=True
+        )
+        
+        blocks = [block1, block2, gap_block]
+        result = aggregator.aggregate_from_blocks(blocks, "daily")
+        
+        assert len(result) >= 2  # At least 2 days of data
+        assert result[0]["date"] == "2024-01-01"
+
+    def test_aggregate_from_blocks_monthly(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+        """Test aggregating from session blocks for monthly view."""
+        from claude_monitor.core.models import SessionBlock
+        
+        block = SessionBlock(
+            id="block1",
+            start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
+            end_time=datetime(2024, 1, 1, 15, 0, tzinfo=timezone.utc),
+            entries=sample_entries,
+            is_gap=False
+        )
+        
+        result = aggregator.aggregate_from_blocks([block], "monthly")
+        
+        assert len(result) == 2  # Jan and Feb
+        assert result[0]["month"] == "2024-01"
+        assert result[1]["month"] == "2024-02"
+
+    def test_aggregate_from_blocks_invalid_view_type(self, aggregator: UsageAggregator) -> None:
+        """Test aggregate_from_blocks with invalid view type."""
+        from claude_monitor.core.models import SessionBlock
+        
+        block = SessionBlock(
+            id="block1",
+            start_time=datetime.now(timezone.utc),
+            end_time=datetime.now(timezone.utc),
+            entries=[],
+            is_gap=False
+        )
+        
+        with pytest.raises(ValueError, match="Invalid view type"):
+            aggregator.aggregate_from_blocks([block], "weekly")
+
+    def test_calculate_totals_empty(self, aggregator: UsageAggregator) -> None:
+        """Test calculating totals with empty data."""
+        result = aggregator.calculate_totals([])
+        
+        assert result["input_tokens"] == 0
+        assert result["output_tokens"] == 0
+        assert result["cache_creation_tokens"] == 0
+        assert result["cache_read_tokens"] == 0
+        assert result["total_tokens"] == 0
+        assert result["total_cost"] == 0.0
+        assert result["entries_count"] == 0
+
+    def test_calculate_totals_with_data(self, aggregator: UsageAggregator) -> None:
+        """Test calculating totals with aggregated data."""
+        aggregated_data = [
+            {
+                "date": "2024-01-01",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_creation_tokens": 100,
+                "cache_read_tokens": 50,
+                "total_cost": 0.05,
+                "entries_count": 10,
+            },
+            {
+                "date": "2024-01-02",
+                "input_tokens": 2000,
+                "output_tokens": 1000,
+                "cache_creation_tokens": 200,
+                "cache_read_tokens": 100,
+                "total_cost": 0.10,
+                "entries_count": 20,
+            },
+        ]
+        
+        result = aggregator.calculate_totals(aggregated_data)
+        
+        assert result["input_tokens"] == 3000
+        assert result["output_tokens"] == 1500
+        assert result["cache_creation_tokens"] == 300
+        assert result["cache_read_tokens"] == 150
+        assert result["total_tokens"] == 4950
+        assert abs(result["total_cost"] - 0.15) < 0.0000001  # Handle floating point precision
+        assert result["entries_count"] == 30
+
+    def test_aggregate_daily_empty_entries(self, aggregator: UsageAggregator) -> None:
+        """Test daily aggregation with empty entries list."""
+        result = aggregator.aggregate_daily([])
+        assert result == []
+
+    def test_aggregate_monthly_empty_entries(self, aggregator: UsageAggregator) -> None:
+        """Test monthly aggregation with empty entries list."""
+        result = aggregator.aggregate_monthly([])
+        assert result == []
+
+    def test_period_sorting(self, aggregator: UsageAggregator) -> None:
+        """Test that periods are sorted correctly."""
+        # Create entries in non-chronological order
+        entries = [
+            UsageEntry(
+                timestamp=datetime(2024, 1, 15, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_3",
+                request_id="req_3",
+            ),
+            UsageEntry(
+                timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_1",
+                request_id="req_1",
+            ),
+            UsageEntry(
+                timestamp=datetime(2024, 1, 10, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_2",
+                request_id="req_2",
+            ),
+        ]
+        
+        # Test daily sorting
+        daily_result = aggregator.aggregate_daily(entries)
+        assert len(daily_result) == 3
+        assert daily_result[0]["date"] == "2024-01-01"
+        assert daily_result[1]["date"] == "2024-01-10"
+        assert daily_result[2]["date"] == "2024-01-15"
+        
+        # Test monthly sorting
+        monthly_entries = [
+            UsageEntry(
+                timestamp=datetime(2024, 3, 1, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_3",
+                request_id="req_3",
+            ),
+            UsageEntry(
+                timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_1",
+                request_id="req_1",
+            ),
+            UsageEntry(
+                timestamp=datetime(2024, 2, 1, 12, 0, tzinfo=timezone.utc),
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=0,
+                cache_read_tokens=0,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id="msg_2",
+                request_id="req_2",
+            ),
+        ]
+        
+        monthly_result = aggregator.aggregate_monthly(monthly_entries)
+        assert len(monthly_result) == 3
+        assert monthly_result[0]["month"] == "2024-01"
+        assert monthly_result[1]["month"] == "2024-02"
+        assert monthly_result[2]["month"] == "2024-03"

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -31,7 +31,7 @@ class TestAggregatedStats:
         """Test adding a single entry to stats."""
         stats = AggregatedStats()
         stats.add_entry(sample_usage_entry)
-        
+
         assert stats.input_tokens == 100
         assert stats.output_tokens == 50
         assert stats.cache_creation_tokens == 10
@@ -42,7 +42,7 @@ class TestAggregatedStats:
     def test_add_entry_multiple(self) -> None:
         """Test adding multiple entries to stats."""
         stats = AggregatedStats()
-        
+
         # Create multiple entries
         entry1 = UsageEntry(
             timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
@@ -55,7 +55,7 @@ class TestAggregatedStats:
             message_id="msg_1",
             request_id="req_1",
         )
-        
+
         entry2 = UsageEntry(
             timestamp=datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc),
             input_tokens=200,
@@ -67,10 +67,10 @@ class TestAggregatedStats:
             message_id="msg_2",
             request_id="req_2",
         )
-        
+
         stats.add_entry(entry1)
         stats.add_entry(entry2)
-        
+
         assert stats.input_tokens == 300
         assert stats.output_tokens == 150
         assert stats.cache_creation_tokens == 30
@@ -88,9 +88,9 @@ class TestAggregatedStats:
             cost=0.05,
             count=10
         )
-        
+
         result = stats.to_dict()
-        
+
         assert result == {
             "input_tokens": 1000,
             "output_tokens": 500,
@@ -107,7 +107,7 @@ class TestAggregatedPeriod:
     def test_init_default_values(self) -> None:
         """Test default initialization of AggregatedPeriod."""
         period = AggregatedPeriod(period_key="2024-01-01")
-        
+
         assert period.period_key == "2024-01-01"
         assert isinstance(period.stats, AggregatedStats)
         assert period.stats.count == 0
@@ -118,17 +118,17 @@ class TestAggregatedPeriod:
         """Test adding a single entry to period."""
         period = AggregatedPeriod(period_key="2024-01-01")
         period.add_entry(sample_usage_entry)
-        
+
         # Check overall stats
         assert period.stats.input_tokens == 100
         assert period.stats.output_tokens == 50
         assert period.stats.cost == 0.001
         assert period.stats.count == 1
-        
+
         # Check models tracking
         assert "claude-3-haiku" in period.models_used
         assert len(period.models_used) == 1
-        
+
         # Check model breakdown
         assert "claude-3-haiku" in period.model_breakdowns
         assert period.model_breakdowns["claude-3-haiku"].input_tokens == 100
@@ -136,7 +136,7 @@ class TestAggregatedPeriod:
     def test_add_entry_multiple_models(self) -> None:
         """Test adding entries with different models."""
         period = AggregatedPeriod(period_key="2024-01-01")
-        
+
         # Add entries with different models
         entry1 = UsageEntry(
             timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
@@ -149,7 +149,7 @@ class TestAggregatedPeriod:
             message_id="msg_1",
             request_id="req_1",
         )
-        
+
         entry2 = UsageEntry(
             timestamp=datetime(2024, 1, 1, 13, 0, tzinfo=timezone.utc),
             input_tokens=200,
@@ -161,7 +161,7 @@ class TestAggregatedPeriod:
             message_id="msg_2",
             request_id="req_2",
         )
-        
+
         entry3 = UsageEntry(
             timestamp=datetime(2024, 1, 1, 14, 0, tzinfo=timezone.utc),
             input_tokens=150,
@@ -173,22 +173,22 @@ class TestAggregatedPeriod:
             message_id="msg_3",
             request_id="req_3",
         )
-        
+
         period.add_entry(entry1)
         period.add_entry(entry2)
         period.add_entry(entry3)
-        
+
         # Check overall stats
         assert period.stats.input_tokens == 450
         assert period.stats.output_tokens == 225
         assert abs(period.stats.cost - 0.0045) < 0.0000001  # Handle floating point precision
         assert period.stats.count == 3
-        
+
         # Check models
         assert len(period.models_used) == 2
         assert "claude-3-haiku" in period.models_used
         assert "claude-3-sonnet" in period.models_used
-        
+
         # Check model breakdowns
         assert period.model_breakdowns["claude-3-haiku"].input_tokens == 250
         assert period.model_breakdowns["claude-3-haiku"].count == 2
@@ -198,7 +198,7 @@ class TestAggregatedPeriod:
     def test_add_entry_with_unknown_model(self) -> None:
         """Test adding entry with None or empty model."""
         period = AggregatedPeriod(period_key="2024-01-01")
-        
+
         entry = UsageEntry(
             timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
             input_tokens=100,
@@ -210,9 +210,9 @@ class TestAggregatedPeriod:
             message_id="msg_1",
             request_id="req_1",
         )
-        
+
         period.add_entry(entry)
-        
+
         assert "unknown" in period.models_used
         assert "unknown" in period.model_breakdowns
 
@@ -244,9 +244,9 @@ class TestAggregatedPeriod:
             cost=0.02,
             count=4
         )
-        
+
         result = period.to_dict("date")
-        
+
         assert result["date"] == "2024-01-01"
         assert result["input_tokens"] == 1000
         assert result["output_tokens"] == 500
@@ -270,9 +270,9 @@ class TestAggregatedPeriod:
             count=100
         )
         period.models_used = {"claude-3-haiku"}
-        
+
         result = period.to_dict("month")
-        
+
         assert result["month"] == "2024-01"
         assert result["input_tokens"] == 10000
         assert result["total_cost"] == 0.5
@@ -290,7 +290,7 @@ class TestUsageAggregator:
     def sample_entries(self) -> List[UsageEntry]:
         """Create sample usage entries spanning multiple days and months."""
         entries = []
-        
+
         # January 2024 entries
         for day in [1, 1, 2, 2, 15, 15, 31]:
             for hour in [10, 14]:
@@ -306,7 +306,7 @@ class TestUsageAggregator:
                     request_id=f"req_{day}_{hour}",
                 )
                 entries.append(entry)
-        
+
         # February 2024 entries
         for day in [1, 15, 29]:
             entry = UsageEntry(
@@ -321,16 +321,16 @@ class TestUsageAggregator:
                 request_id=f"req_feb_{day}",
             )
             entries.append(entry)
-        
+
         return entries
 
     def test_aggregate_daily_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
         """Test basic daily aggregation."""
         result = aggregator.aggregate_daily(sample_entries)
-        
+
         # Should have entries for each unique day
         assert len(result) == 7  # Days: Jan 1, 2, 15, 31, Feb 1, 15, 29
-        
+
         # Check first day (Jan 1 - 4 entries: 2 at 10AM, 2 at 2PM)
         jan1 = result[0]
         assert jan1["date"] == "2024-01-01"
@@ -344,9 +344,9 @@ class TestUsageAggregator:
         """Test daily aggregation with date filters."""
         start_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
         end_date = datetime(2024, 1, 31, 23, 59, 59, tzinfo=timezone.utc)  # Include the whole day
-        
+
         result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
-        
+
         # Should have Jan 15 and Jan 31 (entries on those days are within the filter)
         assert len(result) == 2
         assert result[0]["date"] == "2024-01-15"
@@ -355,10 +355,10 @@ class TestUsageAggregator:
     def test_aggregate_monthly_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
         """Test basic monthly aggregation."""
         result = aggregator.aggregate_monthly(sample_entries)
-        
+
         # Should have 2 months
         assert len(result) == 2
-        
+
         # Check January
         jan = result[0]
         assert jan["month"] == "2024-01"
@@ -367,7 +367,7 @@ class TestUsageAggregator:
         assert abs(jan["total_cost"] - 0.014) < 0.0000001  # Handle floating point precision
         assert jan["entries_count"] == 14
         assert set(jan["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
-        
+
         # Check February
         feb = result[1]
         assert feb["month"] == "2024-02"
@@ -380,9 +380,9 @@ class TestUsageAggregator:
     def test_aggregate_monthly_with_date_filter(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
         """Test monthly aggregation with date filters."""
         start_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
-        
+
         result = aggregator.aggregate_monthly(sample_entries, start_date)
-        
+
         # Should only have February
         assert len(result) == 1
         assert result[0]["month"] == "2024-02"
@@ -391,7 +391,7 @@ class TestUsageAggregator:
         """Test aggregating from session blocks for daily view."""
         # Create mock session blocks
         from claude_monitor.core.models import SessionBlock
-        
+
         block1 = SessionBlock(
             id="block1",
             start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
@@ -399,7 +399,7 @@ class TestUsageAggregator:
             entries=sample_entries[:5],
             is_gap=False
         )
-        
+
         block2 = SessionBlock(
             id="block2",
             start_time=datetime(2024, 1, 2, 10, 0, tzinfo=timezone.utc),
@@ -407,7 +407,7 @@ class TestUsageAggregator:
             entries=sample_entries[5:10],
             is_gap=False
         )
-        
+
         # Gap block should be ignored
         gap_block = SessionBlock(
             id="gap",
@@ -416,17 +416,17 @@ class TestUsageAggregator:
             entries=[],
             is_gap=True
         )
-        
+
         blocks = [block1, block2, gap_block]
         result = aggregator.aggregate_from_blocks(blocks, "daily")
-        
+
         assert len(result) >= 2  # At least 2 days of data
         assert result[0]["date"] == "2024-01-01"
 
     def test_aggregate_from_blocks_monthly(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
         """Test aggregating from session blocks for monthly view."""
         from claude_monitor.core.models import SessionBlock
-        
+
         block = SessionBlock(
             id="block1",
             start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
@@ -434,9 +434,9 @@ class TestUsageAggregator:
             entries=sample_entries,
             is_gap=False
         )
-        
+
         result = aggregator.aggregate_from_blocks([block], "monthly")
-        
+
         assert len(result) == 2  # Jan and Feb
         assert result[0]["month"] == "2024-01"
         assert result[1]["month"] == "2024-02"
@@ -444,7 +444,7 @@ class TestUsageAggregator:
     def test_aggregate_from_blocks_invalid_view_type(self, aggregator: UsageAggregator) -> None:
         """Test aggregate_from_blocks with invalid view type."""
         from claude_monitor.core.models import SessionBlock
-        
+
         block = SessionBlock(
             id="block1",
             start_time=datetime.now(timezone.utc),
@@ -452,14 +452,14 @@ class TestUsageAggregator:
             entries=[],
             is_gap=False
         )
-        
+
         with pytest.raises(ValueError, match="Invalid view type"):
             aggregator.aggregate_from_blocks([block], "weekly")
 
     def test_calculate_totals_empty(self, aggregator: UsageAggregator) -> None:
         """Test calculating totals with empty data."""
         result = aggregator.calculate_totals([])
-        
+
         assert result["input_tokens"] == 0
         assert result["output_tokens"] == 0
         assert result["cache_creation_tokens"] == 0
@@ -490,9 +490,9 @@ class TestUsageAggregator:
                 "entries_count": 20,
             },
         ]
-        
+
         result = aggregator.calculate_totals(aggregated_data)
-        
+
         assert result["input_tokens"] == 3000
         assert result["output_tokens"] == 1500
         assert result["cache_creation_tokens"] == 300
@@ -549,14 +549,14 @@ class TestUsageAggregator:
                 request_id="req_2",
             ),
         ]
-        
+
         # Test daily sorting
         daily_result = aggregator.aggregate_daily(entries)
         assert len(daily_result) == 3
         assert daily_result[0]["date"] == "2024-01-01"
         assert daily_result[1]["date"] == "2024-01-10"
         assert daily_result[2]["date"] == "2024-01-15"
-        
+
         # Test monthly sorting
         monthly_entries = [
             UsageEntry(
@@ -593,7 +593,7 @@ class TestUsageAggregator:
                 request_id="req_2",
             ),
         ]
-        
+
         monthly_result = aggregator.aggregate_monthly(monthly_entries)
         assert len(monthly_result) == 3
         assert monthly_result[0]["month"] == "2024-01"

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -2,14 +2,13 @@
 
 from datetime import datetime, timezone
 from typing import List
-from unittest.mock import Mock
 
 import pytest
 
 from claude_monitor.core.models import UsageEntry
 from claude_monitor.data.aggregator import (
-    AggregatedStats,
     AggregatedPeriod,
+    AggregatedStats,
     UsageAggregator,
 )
 

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -2,7 +2,7 @@
 
 from datetime import datetime, timezone
 from typing import List
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -1,16 +1,15 @@
 """Tests for data aggregator module."""
 
-from datetime import datetime, timezone
+from datetime import datetime
+from datetime import timezone
 from typing import List
 
 import pytest
 
 from claude_monitor.core.models import UsageEntry
-from claude_monitor.data.aggregator import (
-    AggregatedPeriod,
-    AggregatedStats,
-    UsageAggregator,
-)
+from claude_monitor.data.aggregator import AggregatedPeriod
+from claude_monitor.data.aggregator import AggregatedStats
+from claude_monitor.data.aggregator import UsageAggregator
 
 
 class TestAggregatedStats:
@@ -85,7 +84,7 @@ class TestAggregatedStats:
             cache_creation_tokens=100,
             cache_read_tokens=50,
             cost=0.05,
-            count=10
+            count=10,
         )
 
         result = stats.to_dict()
@@ -180,7 +179,9 @@ class TestAggregatedPeriod:
         # Check overall stats
         assert period.stats.input_tokens == 450
         assert period.stats.output_tokens == 225
-        assert abs(period.stats.cost - 0.0045) < 0.0000001  # Handle floating point precision
+        assert (
+            abs(period.stats.cost - 0.0045) < 0.0000001
+        )  # Handle floating point precision
         assert period.stats.count == 3
 
         # Check models
@@ -224,7 +225,7 @@ class TestAggregatedPeriod:
             cache_creation_tokens=100,
             cache_read_tokens=50,
             cost=0.05,
-            count=10
+            count=10,
         )
         period.models_used = {"claude-3-haiku", "claude-3-sonnet"}
         period.model_breakdowns["claude-3-haiku"] = AggregatedStats(
@@ -233,7 +234,7 @@ class TestAggregatedPeriod:
             cache_creation_tokens=60,
             cache_read_tokens=30,
             cost=0.03,
-            count=6
+            count=6,
         )
         period.model_breakdowns["claude-3-sonnet"] = AggregatedStats(
             input_tokens=400,
@@ -241,7 +242,7 @@ class TestAggregatedPeriod:
             cache_creation_tokens=40,
             cache_read_tokens=20,
             cost=0.02,
-            count=4
+            count=4,
         )
 
         result = period.to_dict("date")
@@ -266,7 +267,7 @@ class TestAggregatedPeriod:
             cache_creation_tokens=1000,
             cache_read_tokens=500,
             cost=0.5,
-            count=100
+            count=100,
         )
         period.models_used = {"claude-3-haiku"}
 
@@ -323,7 +324,9 @@ class TestUsageAggregator:
 
         return entries
 
-    def test_aggregate_daily_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_daily_basic(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test basic daily aggregation."""
         result = aggregator.aggregate_daily(sample_entries)
 
@@ -339,10 +342,14 @@ class TestUsageAggregator:
         assert jan1["entries_count"] == 4
         assert set(jan1["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
 
-    def test_aggregate_daily_with_date_filter(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_daily_with_date_filter(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test daily aggregation with date filters."""
         start_date = datetime(2024, 1, 15, tzinfo=timezone.utc)
-        end_date = datetime(2024, 1, 31, 23, 59, 59, tzinfo=timezone.utc)  # Include the whole day
+        end_date = datetime(
+            2024, 1, 31, 23, 59, 59, tzinfo=timezone.utc
+        )  # Include the whole day
 
         result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
 
@@ -351,7 +358,9 @@ class TestUsageAggregator:
         assert result[0]["date"] == "2024-01-15"
         assert result[1]["date"] == "2024-01-31"
 
-    def test_aggregate_monthly_basic(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_monthly_basic(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test basic monthly aggregation."""
         result = aggregator.aggregate_monthly(sample_entries)
 
@@ -362,21 +371,25 @@ class TestUsageAggregator:
         jan = result[0]
         assert jan["month"] == "2024-01"
         assert jan["input_tokens"] == 1400  # 14 entries * 100
-        assert jan["output_tokens"] == 700   # 14 entries * 50
-        assert abs(jan["total_cost"] - 0.014) < 0.0000001  # Handle floating point precision
+        assert jan["output_tokens"] == 700  # 14 entries * 50
+        assert (
+            abs(jan["total_cost"] - 0.014) < 0.0000001
+        )  # Handle floating point precision
         assert jan["entries_count"] == 14
         assert set(jan["models_used"]) == {"claude-3-haiku", "claude-3-sonnet"}
 
         # Check February
         feb = result[1]
         assert feb["month"] == "2024-02"
-        assert feb["input_tokens"] == 600   # 3 entries * 200
+        assert feb["input_tokens"] == 600  # 3 entries * 200
         assert feb["output_tokens"] == 300  # 3 entries * 100
         assert feb["total_cost"] == 0.006  # 3 entries * 0.002
         assert feb["entries_count"] == 3
         assert feb["models_used"] == ["claude-3-opus"]
 
-    def test_aggregate_monthly_with_date_filter(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_monthly_with_date_filter(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test monthly aggregation with date filters."""
         start_date = datetime(2024, 2, 1, tzinfo=timezone.utc)
 
@@ -386,7 +399,9 @@ class TestUsageAggregator:
         assert len(result) == 1
         assert result[0]["month"] == "2024-02"
 
-    def test_aggregate_from_blocks_daily(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_from_blocks_daily(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test aggregating from session blocks for daily view."""
         # Create mock session blocks
         from claude_monitor.core.models import SessionBlock
@@ -396,7 +411,7 @@ class TestUsageAggregator:
             start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
             end_time=datetime(2024, 1, 1, 15, 0, tzinfo=timezone.utc),
             entries=sample_entries[:5],
-            is_gap=False
+            is_gap=False,
         )
 
         block2 = SessionBlock(
@@ -404,7 +419,7 @@ class TestUsageAggregator:
             start_time=datetime(2024, 1, 2, 10, 0, tzinfo=timezone.utc),
             end_time=datetime(2024, 1, 2, 15, 0, tzinfo=timezone.utc),
             entries=sample_entries[5:10],
-            is_gap=False
+            is_gap=False,
         )
 
         # Gap block should be ignored
@@ -413,7 +428,7 @@ class TestUsageAggregator:
             start_time=datetime(2024, 1, 3, 10, 0, tzinfo=timezone.utc),
             end_time=datetime(2024, 1, 3, 15, 0, tzinfo=timezone.utc),
             entries=[],
-            is_gap=True
+            is_gap=True,
         )
 
         blocks = [block1, block2, gap_block]
@@ -422,7 +437,9 @@ class TestUsageAggregator:
         assert len(result) >= 2  # At least 2 days of data
         assert result[0]["date"] == "2024-01-01"
 
-    def test_aggregate_from_blocks_monthly(self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]) -> None:
+    def test_aggregate_from_blocks_monthly(
+        self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
+    ) -> None:
         """Test aggregating from session blocks for monthly view."""
         from claude_monitor.core.models import SessionBlock
 
@@ -431,7 +448,7 @@ class TestUsageAggregator:
             start_time=datetime(2024, 1, 1, 10, 0, tzinfo=timezone.utc),
             end_time=datetime(2024, 1, 1, 15, 0, tzinfo=timezone.utc),
             entries=sample_entries,
-            is_gap=False
+            is_gap=False,
         )
 
         result = aggregator.aggregate_from_blocks([block], "monthly")
@@ -440,7 +457,9 @@ class TestUsageAggregator:
         assert result[0]["month"] == "2024-01"
         assert result[1]["month"] == "2024-02"
 
-    def test_aggregate_from_blocks_invalid_view_type(self, aggregator: UsageAggregator) -> None:
+    def test_aggregate_from_blocks_invalid_view_type(
+        self, aggregator: UsageAggregator
+    ) -> None:
         """Test aggregate_from_blocks with invalid view type."""
         from claude_monitor.core.models import SessionBlock
 
@@ -449,7 +468,7 @@ class TestUsageAggregator:
             start_time=datetime.now(timezone.utc),
             end_time=datetime.now(timezone.utc),
             entries=[],
-            is_gap=False
+            is_gap=False,
         )
 
         with pytest.raises(ValueError, match="Invalid view type"):
@@ -497,7 +516,9 @@ class TestUsageAggregator:
         assert result["cache_creation_tokens"] == 300
         assert result["cache_read_tokens"] == 150
         assert result["total_tokens"] == 4950
-        assert abs(result["total_cost"] - 0.15) < 0.0000001  # Handle floating point precision
+        assert (
+            abs(result["total_cost"] - 0.15) < 0.0000001
+        )  # Handle floating point precision
         assert result["entries_count"] == 30
 
     def test_aggregate_daily_empty_entries(self, aggregator: UsageAggregator) -> None:

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -1,6 +1,6 @@
 """Tests for data aggregator module."""
 
-from datetime import datetime, timezone, timedelta
+from datetime import datetime, timezone
 from typing import List
 from unittest.mock import Mock, patch
 

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -1,15 +1,16 @@
 """Tests for data aggregator module."""
 
-from datetime import datetime
-from datetime import timezone
+from datetime import datetime, timezone
 from typing import List
 
 import pytest
 
 from claude_monitor.core.models import UsageEntry
-from claude_monitor.data.aggregator import AggregatedPeriod
-from claude_monitor.data.aggregator import AggregatedStats
-from claude_monitor.data.aggregator import UsageAggregator
+from claude_monitor.data.aggregator import (
+    AggregatedPeriod,
+    AggregatedStats,
+    UsageAggregator,
+)
 
 
 class TestAggregatedStats:

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -282,9 +282,9 @@ class TestUsageAggregator:
     """Test cases for UsageAggregator class."""
 
     @pytest.fixture
-    def aggregator(self) -> UsageAggregator:
+    def aggregator(self, tmp_path) -> UsageAggregator:
         """Create a UsageAggregator instance."""
-        return UsageAggregator()
+        return UsageAggregator(data_path=str(tmp_path))
 
     @pytest.fixture
     def sample_entries(self) -> List[UsageEntry]:

--- a/src/tests/test_cli_main.py
+++ b/src/tests/test_cli_main.py
@@ -76,11 +76,17 @@ class TestMain:
             with (
                 patch("claude_monitor.terminal.manager.setup_terminal"),
                 patch("claude_monitor.terminal.themes.get_themed_console"),
-                patch("claude_monitor.ui.display_controller.DisplayController"),
-                patch("claude_monitor.monitoring.orchestrator.MonitoringOrchestrator"),
-                patch("time.sleep", side_effect=KeyboardInterrupt),
+                patch("claude_monitor.ui.display_controller.DisplayController") as mock_display,
+                patch("claude_monitor.monitoring.orchestrator.MonitoringOrchestrator") as mock_orchestrator,
+                patch("signal.pause", side_effect=KeyboardInterrupt()),
+                patch("time.sleep", side_effect=KeyboardInterrupt()),
                 patch("sys.exit"),
             ):  # Don't actually exit
+                # Configure mocks to not interfere with the KeyboardInterrupt
+                mock_orchestrator.return_value.wait_for_initial_data.return_value = True
+                mock_orchestrator.return_value.start.return_value = None
+                mock_orchestrator.return_value.stop.return_value = None
+                
                 result = main(["--plan", "pro"])
                 assert result == 0
         finally:

--- a/src/tests/test_cli_main.py
+++ b/src/tests/test_cli_main.py
@@ -1,7 +1,8 @@
 """Simplified tests for CLI main module."""
 
 from pathlib import Path
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
+from unittest.mock import patch
 
 from claude_monitor.cli.main import main
 

--- a/src/tests/test_cli_main.py
+++ b/src/tests/test_cli_main.py
@@ -1,8 +1,7 @@
 """Simplified tests for CLI main module."""
 
 from pathlib import Path
-from unittest.mock import Mock
-from unittest.mock import patch
+from unittest.mock import Mock, patch
 
 from claude_monitor.cli.main import main
 

--- a/src/tests/test_cli_main.py
+++ b/src/tests/test_cli_main.py
@@ -76,8 +76,10 @@ class TestMain:
             with (
                 patch("claude_monitor.terminal.manager.setup_terminal"),
                 patch("claude_monitor.terminal.themes.get_themed_console"),
-                patch("claude_monitor.ui.display_controller.DisplayController") as mock_display,
-                patch("claude_monitor.monitoring.orchestrator.MonitoringOrchestrator") as mock_orchestrator,
+                patch("claude_monitor.ui.display_controller.DisplayController"),
+                patch(
+                    "claude_monitor.monitoring.orchestrator.MonitoringOrchestrator"
+                ) as mock_orchestrator,
                 patch("signal.pause", side_effect=KeyboardInterrupt()),
                 patch("time.sleep", side_effect=KeyboardInterrupt()),
                 patch("sys.exit"),
@@ -86,7 +88,7 @@ class TestMain:
                 mock_orchestrator.return_value.wait_for_initial_data.return_value = True
                 mock_orchestrator.return_value.start.return_value = None
                 mock_orchestrator.return_value.stop.return_value = None
-                
+
                 result = main(["--plan", "pro"])
                 assert result == 0
         finally:

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -3,13 +3,18 @@
 import argparse
 import json
 import tempfile
+
 from pathlib import Path
-from typing import Dict, List, Union
-from unittest.mock import Mock, patch
+from typing import Dict
+from typing import List
+from typing import Union
+from unittest.mock import Mock
+from unittest.mock import patch
 
 import pytest
 
-from claude_monitor.core.settings import LastUsedParams, Settings
+from claude_monitor.core.settings import LastUsedParams
+from claude_monitor.core.settings import Settings
 
 
 class TestLastUsedParams:
@@ -43,16 +48,20 @@ class TestLastUsedParams:
     def test_save_success(self) -> None:
         """Test successful saving of parameters."""
         # Create mock settings with type object
-        mock_settings = type('MockSettings', (), {
-            'plan': 'pro',
-            'theme': 'dark',
-            'timezone': 'UTC',
-            'time_format': '24h',
-            'refresh_rate': 5,
-            'reset_hour': 12,
-            'custom_limit_tokens': 1000,
-            'view': 'realtime'
-        })()
+        mock_settings = type(
+            "MockSettings",
+            (),
+            {
+                "plan": "pro",
+                "theme": "dark",
+                "timezone": "UTC",
+                "time_format": "24h",
+                "refresh_rate": 5,
+                "reset_hour": 12,
+                "custom_limit_tokens": 1000,
+                "view": "realtime",
+            },
+        )()
 
         # Save parameters
         self.last_used.save(mock_settings)
@@ -76,16 +85,20 @@ class TestLastUsedParams:
 
     def test_save_without_custom_limit(self) -> None:
         """Test saving without custom limit tokens."""
-        mock_settings = type('MockSettings', (), {
-            'plan': 'pro',
-            'theme': 'light',
-            'timezone': 'UTC',
-            'time_format': '12h',
-            'refresh_rate': 10,
-            'reset_hour': None,
-            'custom_limit_tokens': None,
-            'view': 'realtime'
-        })()
+        mock_settings = type(
+            "MockSettings",
+            (),
+            {
+                "plan": "pro",
+                "theme": "light",
+                "timezone": "UTC",
+                "time_format": "12h",
+                "refresh_rate": 10,
+                "reset_hour": None,
+                "custom_limit_tokens": None,
+                "view": "realtime",
+            },
+        )()
 
         self.last_used.save(mock_settings)
 
@@ -101,16 +114,20 @@ class TestLastUsedParams:
         non_existent_dir = self.temp_dir / "non-existent"
         last_used = LastUsedParams(non_existent_dir)
 
-        mock_settings = type('MockSettings', (), {
-            'plan': 'pro',
-            'theme': 'dark',
-            'timezone': 'UTC',
-            'time_format': '24h',
-            'refresh_rate': 5,
-            'reset_hour': 12,
-            'custom_limit_tokens': None,
-            'view': 'realtime'
-        })()
+        mock_settings = type(
+            "MockSettings",
+            (),
+            {
+                "plan": "pro",
+                "theme": "dark",
+                "timezone": "UTC",
+                "time_format": "24h",
+                "refresh_rate": 5,
+                "reset_hour": 12,
+                "custom_limit_tokens": None,
+                "view": "realtime",
+            },
+        )()
 
         last_used.save(mock_settings)
 

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -3,18 +3,13 @@
 import argparse
 import json
 import tempfile
-
 from pathlib import Path
-from typing import Dict
-from typing import List
-from typing import Union
-from unittest.mock import Mock
-from unittest.mock import patch
+from typing import Dict, List, Union
+from unittest.mock import Mock, patch
 
 import pytest
 
-from claude_monitor.core.settings import LastUsedParams
-from claude_monitor.core.settings import Settings
+from claude_monitor.core.settings import LastUsedParams, Settings
 
 
 class TestLastUsedParams:

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -42,15 +42,17 @@ class TestLastUsedParams:
 
     def test_save_success(self) -> None:
         """Test successful saving of parameters."""
-        # Create mock settings
-        mock_settings = Mock()
-        mock_settings.plan = "pro"
-        mock_settings.theme = "dark"
-        mock_settings.timezone = "UTC"
-        mock_settings.time_format = "24h"
-        mock_settings.refresh_rate = 5
-        mock_settings.reset_hour = 12
-        mock_settings.custom_limit_tokens = 1000
+        # Create mock settings with type object
+        mock_settings = type('MockSettings', (), {
+            'plan': 'pro',
+            'theme': 'dark',
+            'timezone': 'UTC',
+            'time_format': '24h',
+            'refresh_rate': 5,
+            'reset_hour': 12,
+            'custom_limit_tokens': 1000,
+            'view': 'realtime'
+        })()
 
         # Save parameters
         self.last_used.save(mock_settings)
@@ -69,18 +71,21 @@ class TestLastUsedParams:
         assert data["refresh_rate"] == 5
         assert data["reset_hour"] == 12
         assert data["custom_limit_tokens"] == 1000
+        assert data["view"] == "realtime"
         assert "timestamp" in data
 
     def test_save_without_custom_limit(self) -> None:
         """Test saving without custom limit tokens."""
-        mock_settings = Mock()
-        mock_settings.plan = "pro"
-        mock_settings.theme = "light"
-        mock_settings.timezone = "UTC"
-        mock_settings.time_format = "12h"
-        mock_settings.refresh_rate = 10
-        mock_settings.reset_hour = None
-        mock_settings.custom_limit_tokens = None
+        mock_settings = type('MockSettings', (), {
+            'plan': 'pro',
+            'theme': 'light',
+            'timezone': 'UTC',
+            'time_format': '12h',
+            'refresh_rate': 10,
+            'reset_hour': None,
+            'custom_limit_tokens': None,
+            'view': 'realtime'
+        })()
 
         self.last_used.save(mock_settings)
 
@@ -96,14 +101,16 @@ class TestLastUsedParams:
         non_existent_dir = self.temp_dir / "non-existent"
         last_used = LastUsedParams(non_existent_dir)
 
-        mock_settings = Mock()
-        mock_settings.plan = "pro"
-        mock_settings.theme = "dark"
-        mock_settings.timezone = "UTC"
-        mock_settings.time_format = "24h"
-        mock_settings.refresh_rate = 5
-        mock_settings.reset_hour = 12
-        mock_settings.custom_limit_tokens = None
+        mock_settings = type('MockSettings', (), {
+            'plan': 'pro',
+            'theme': 'dark',
+            'timezone': 'UTC',
+            'time_format': '24h',
+            'refresh_rate': 5,
+            'reset_hour': 12,
+            'custom_limit_tokens': None,
+            'view': 'realtime'
+        })()
 
         last_used.save(mock_settings)
 
@@ -123,6 +130,7 @@ class TestLastUsedParams:
             mock_settings.refresh_rate = 5
             mock_settings.reset_hour = 12
             mock_settings.custom_limit_tokens = None
+            mock_settings.view = "realtime"
 
             # Should not raise exception
             self.last_used.save(mock_settings)
@@ -141,6 +149,7 @@ class TestLastUsedParams:
             "reset_hour": 8,
             "custom_limit_tokens": 2000,
             "timestamp": "2024-01-01T12:00:00",
+            "view": "realtime",
         }
 
         with open(self.last_used.params_file, "w") as f:
@@ -415,6 +424,7 @@ class TestSettings:
             "timezone": "Europe/Warsaw",
             "refresh_rate": 15,
             "custom_limit_tokens": 5000,
+            "view": "realtime",
         }
 
         with patch("claude_monitor.core.settings.LastUsedParams") as MockLastUsed:
@@ -447,6 +457,7 @@ class TestSettings:
             "theme": "dark",
             "timezone": "Europe/Warsaw",
             "refresh_rate": 15,
+            "view": "realtime",
         }
 
         with patch("claude_monitor.core.settings.LastUsedParams") as MockLastUsed:

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -1,0 +1,399 @@
+"""Tests for table views module."""
+
+from typing import Any, Dict, List
+from unittest.mock import Mock, patch
+
+import pytest
+from rich.table import Table
+from rich.panel import Panel
+from rich.text import Text
+
+from claude_monitor.ui.table_views import TableViewsController
+
+
+class TestTableViewsController:
+    """Test cases for TableViewsController class."""
+
+    @pytest.fixture
+    def controller(self) -> TableViewsController:
+        """Create a TableViewsController instance."""
+        return TableViewsController()
+
+    @pytest.fixture
+    def sample_daily_data(self) -> List[Dict[str, Any]]:
+        """Create sample daily aggregated data."""
+        return [
+            {
+                "date": "2024-01-01",
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "cache_creation_tokens": 100,
+                "cache_read_tokens": 50,
+                "total_cost": 0.05,
+                "models_used": ["claude-3-haiku", "claude-3-sonnet"],
+                "model_breakdowns": {
+                    "claude-3-haiku": {
+                        "input_tokens": 600,
+                        "output_tokens": 300,
+                        "cache_creation_tokens": 60,
+                        "cache_read_tokens": 30,
+                        "cost": 0.03,
+                        "count": 6,
+                    },
+                    "claude-3-sonnet": {
+                        "input_tokens": 400,
+                        "output_tokens": 200,
+                        "cache_creation_tokens": 40,
+                        "cache_read_tokens": 20,
+                        "cost": 0.02,
+                        "count": 4,
+                    },
+                },
+                "entries_count": 10,
+            },
+            {
+                "date": "2024-01-02",
+                "input_tokens": 2000,
+                "output_tokens": 1000,
+                "cache_creation_tokens": 200,
+                "cache_read_tokens": 100,
+                "total_cost": 0.10,
+                "models_used": ["claude-3-opus"],
+                "model_breakdowns": {
+                    "claude-3-opus": {
+                        "input_tokens": 2000,
+                        "output_tokens": 1000,
+                        "cache_creation_tokens": 200,
+                        "cache_read_tokens": 100,
+                        "cost": 0.10,
+                        "count": 20,
+                    },
+                },
+                "entries_count": 20,
+            },
+        ]
+
+    @pytest.fixture
+    def sample_monthly_data(self) -> List[Dict[str, Any]]:
+        """Create sample monthly aggregated data."""
+        return [
+            {
+                "month": "2024-01",
+                "input_tokens": 30000,
+                "output_tokens": 15000,
+                "cache_creation_tokens": 3000,
+                "cache_read_tokens": 1500,
+                "total_cost": 1.50,
+                "models_used": ["claude-3-haiku", "claude-3-sonnet", "claude-3-opus"],
+                "model_breakdowns": {
+                    "claude-3-haiku": {
+                        "input_tokens": 10000,
+                        "output_tokens": 5000,
+                        "cache_creation_tokens": 1000,
+                        "cache_read_tokens": 500,
+                        "cost": 0.50,
+                        "count": 100,
+                    },
+                    "claude-3-sonnet": {
+                        "input_tokens": 10000,
+                        "output_tokens": 5000,
+                        "cache_creation_tokens": 1000,
+                        "cache_read_tokens": 500,
+                        "cost": 0.50,
+                        "count": 100,
+                    },
+                    "claude-3-opus": {
+                        "input_tokens": 10000,
+                        "output_tokens": 5000,
+                        "cache_creation_tokens": 1000,
+                        "cache_read_tokens": 500,
+                        "cost": 0.50,
+                        "count": 100,
+                    },
+                },
+                "entries_count": 300,
+            },
+            {
+                "month": "2024-02",
+                "input_tokens": 20000,
+                "output_tokens": 10000,
+                "cache_creation_tokens": 2000,
+                "cache_read_tokens": 1000,
+                "total_cost": 1.00,
+                "models_used": ["claude-3-haiku"],
+                "model_breakdowns": {
+                    "claude-3-haiku": {
+                        "input_tokens": 20000,
+                        "output_tokens": 10000,
+                        "cache_creation_tokens": 2000,
+                        "cache_read_tokens": 1000,
+                        "cost": 1.00,
+                        "count": 200,
+                    },
+                },
+                "entries_count": 200,
+            },
+        ]
+
+    @pytest.fixture
+    def sample_totals(self) -> Dict[str, Any]:
+        """Create sample totals data."""
+        return {
+            "input_tokens": 50000,
+            "output_tokens": 25000,
+            "cache_creation_tokens": 5000,
+            "cache_read_tokens": 2500,
+            "total_tokens": 82500,
+            "total_cost": 2.50,
+            "entries_count": 500,
+        }
+
+    def test_init_styles(self, controller: TableViewsController) -> None:
+        """Test controller initialization with styles."""
+        assert controller.key_style == "cyan"
+        assert controller.value_style == "white"
+        assert controller.accent_style == "yellow"
+        assert controller.success_style == "green"
+        assert controller.warning_style == "yellow"
+        assert controller.header_style == "bold cyan"
+        assert controller.table_header_style == "bold"
+        assert controller.border_style == "bright_blue"
+
+    def test_create_daily_table_structure(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test creation of daily table structure."""
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
+        
+        assert isinstance(table, Table)
+        assert table.title == "Claude Code Token Usage Report - Daily (UTC)"
+        assert table.title_style == "bold cyan"
+        assert table.show_header is True
+        assert table.header_style == "bold"
+        assert table.border_style == "bright_blue"
+        assert table.expand is True
+        assert table.show_lines is True
+        
+        # Check columns
+        assert len(table.columns) == 8
+        assert table.columns[0].header == "Date"
+        assert table.columns[1].header == "Models"
+        assert table.columns[2].header == "Input"
+        assert table.columns[3].header == "Output"
+        assert table.columns[4].header == "Cache Create"
+        assert table.columns[5].header == "Cache Read"
+        assert table.columns[6].header == "Total Tokens"
+        assert table.columns[7].header == "Cost (USD)"
+
+    def test_create_daily_table_data(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test daily table data population."""
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
+        
+        # The table should have:
+        # - 2 data rows (for the 2 days)
+        # - 1 separator row
+        # - 1 totals row
+        # Total: 4 rows
+        assert table.row_count == 4
+
+    def test_create_monthly_table_structure(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test creation of monthly table structure."""
+        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
+        
+        assert isinstance(table, Table)
+        assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
+        assert table.title_style == "bold cyan"
+        assert table.show_header is True
+        assert table.header_style == "bold"
+        assert table.border_style == "bright_blue"
+        assert table.expand is True
+        assert table.show_lines is True
+        
+        # Check columns
+        assert len(table.columns) == 8
+        assert table.columns[0].header == "Month"
+        assert table.columns[1].header == "Models"
+        assert table.columns[2].header == "Input"
+        assert table.columns[3].header == "Output"
+        assert table.columns[4].header == "Cache Create"
+        assert table.columns[5].header == "Cache Read"
+        assert table.columns[6].header == "Total Tokens"
+        assert table.columns[7].header == "Cost (USD)"
+
+    def test_create_monthly_table_data(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test monthly table data population."""
+        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
+        
+        # The table should have:
+        # - 2 data rows (for the 2 months)
+        # - 1 separator row
+        # - 1 totals row
+        # Total: 4 rows
+        assert table.row_count == 4
+
+    def test_create_summary_panel(self, controller: TableViewsController, sample_totals: Dict[str, Any]) -> None:
+        """Test creation of summary panel."""
+        panel = controller.create_summary_panel("daily", sample_totals, "Last 30 days")
+        
+        assert isinstance(panel, Panel)
+        assert panel.title == "Summary"
+        assert panel.title_align == "center"
+        assert panel.border_style == controller.border_style
+        assert panel.expand is False
+        assert panel.padding == (1, 2)
+
+    def test_format_models_single(self, controller: TableViewsController) -> None:
+        """Test formatting single model."""
+        result = controller._format_models(["claude-3-haiku"])
+        assert result == "claude-3-haiku"
+
+    def test_format_models_multiple(self, controller: TableViewsController) -> None:
+        """Test formatting multiple models."""
+        result = controller._format_models(["claude-3-haiku", "claude-3-sonnet", "claude-3-opus"])
+        expected = "• claude-3-haiku\n• claude-3-sonnet\n• claude-3-opus"
+        assert result == expected
+
+    def test_format_models_empty(self, controller: TableViewsController) -> None:
+        """Test formatting empty models list."""
+        result = controller._format_models([])
+        assert result == "No models"
+
+    def test_create_no_data_display(self, controller: TableViewsController) -> None:
+        """Test creation of no data display."""
+        panel = controller.create_no_data_display("daily")
+        
+        assert isinstance(panel, Panel)
+        assert panel.title == "No Daily Data"
+        assert panel.title_align == "center"
+        assert panel.border_style == controller.warning_style
+        assert panel.expand is True
+        assert panel.height == 10
+
+    def test_create_aggregate_table_daily(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test create_aggregate_table for daily view."""
+        table = controller.create_aggregate_table(sample_daily_data, sample_totals, "daily", "UTC")
+        
+        assert isinstance(table, Table)
+        assert table.title == "Claude Code Token Usage Report - Daily (UTC)"
+
+    def test_create_aggregate_table_monthly(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test create_aggregate_table for monthly view."""
+        table = controller.create_aggregate_table(sample_monthly_data, sample_totals, "monthly", "UTC")
+        
+        assert isinstance(table, Table)
+        assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
+
+    def test_create_aggregate_table_invalid_view_type(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test create_aggregate_table with invalid view type."""
+        with pytest.raises(ValueError, match="Invalid view type"):
+            controller.create_aggregate_table(sample_daily_data, sample_totals, "weekly", "UTC")
+
+    def test_daily_table_timezone_display(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test daily table displays correct timezone."""
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "America/New_York")
+        assert table.title == "Claude Code Token Usage Report - Daily (America/New_York)"
+
+    def test_monthly_table_timezone_display(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test monthly table displays correct timezone."""
+        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "Europe/London")
+        assert table.title == "Claude Code Token Usage Report - Monthly (Europe/London)"
+
+    def test_table_with_zero_tokens(self, controller: TableViewsController) -> None:
+        """Test table with entries having zero tokens."""
+        data = [
+            {
+                "date": "2024-01-01",
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "cache_creation_tokens": 0,
+                "cache_read_tokens": 0,
+                "total_cost": 0.0,
+                "models_used": ["claude-3-haiku"],
+                "model_breakdowns": {},
+                "entries_count": 0,
+            }
+        ]
+        
+        totals = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "total_tokens": 0,
+            "total_cost": 0.0,
+            "entries_count": 0,
+        }
+        
+        table = controller.create_daily_table(data, totals, "UTC")
+        # Table should have 3 rows:
+        # - 1 data row
+        # - 1 separator row (empty)  
+        # - 1 totals row
+        # Note: Rich table doesn't count empty separator as a row in some versions
+        assert table.row_count in [3, 4]  # Allow for version differences
+
+    def test_summary_panel_different_periods(self, controller: TableViewsController, sample_totals: Dict[str, Any]) -> None:
+        """Test summary panel with different period descriptions."""
+        periods = [
+            "Last 30 days",
+            "Last 7 days",
+            "January 2024",
+            "Q1 2024",
+            "Year to date",
+        ]
+        
+        for period in periods:
+            panel = controller.create_summary_panel("daily", sample_totals, period)
+            assert isinstance(panel, Panel)
+            assert panel.title == "Summary"
+
+    def test_no_data_display_different_view_types(self, controller: TableViewsController) -> None:
+        """Test no data display for different view types."""
+        for view_type in ["daily", "monthly", "weekly", "yearly"]:
+            panel = controller.create_no_data_display(view_type)
+            assert isinstance(panel, Panel)
+            assert panel.title == f"No {view_type.capitalize()} Data"
+
+    def test_number_formatting_integration(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test that number formatting is integrated correctly."""
+        # Test that the table can be created with real formatting functions
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
+        
+        # Verify table was created successfully
+        assert table is not None
+        assert table.row_count >= 3  # At least data rows + separator + totals
+
+    def test_currency_formatting_integration(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test that currency formatting is integrated correctly."""
+        # Test that the table can be created with real formatting functions
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
+        
+        # Verify table was created successfully
+        assert table is not None
+        assert table.row_count >= 3  # At least data rows + separator + totals
+
+    def test_table_column_alignment(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+        """Test that numeric columns are right-aligned."""
+        table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
+        
+        # Check that numeric columns are right-aligned
+        for i in range(2, 8):  # Columns 2-7 are numeric
+            assert table.columns[i].justify == "right"
+
+    def test_empty_data_lists(self, controller: TableViewsController) -> None:
+        """Test handling of empty data lists."""
+        empty_totals = {
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cache_read_tokens": 0,
+            "total_tokens": 0,
+            "total_cost": 0.0,
+            "entries_count": 0,
+        }
+        
+        # Daily table with empty data
+        daily_table = controller.create_daily_table([], empty_totals, "UTC")
+        assert daily_table.row_count == 2  # Separator + totals
+        
+        # Monthly table with empty data
+        monthly_table = controller.create_monthly_table([], empty_totals, "UTC")
+        assert monthly_table.row_count == 2  # Separator + totals

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -3,8 +3,8 @@
 from typing import Any, Dict, List
 
 import pytest
-from rich.table import Table
 from rich.panel import Panel
+from rich.table import Table
 
 from claude_monitor.ui.table_views import TableViewsController
 

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -1,8 +1,11 @@
 """Tests for table views module."""
 
-from typing import Any, Dict, List
+from typing import Any
+from typing import Dict
+from typing import List
 
 import pytest
+
 from rich.panel import Panel
 from rich.table import Table
 
@@ -157,7 +160,12 @@ class TestTableViewsController:
         assert controller.table_header_style == "bold"
         assert controller.border_style == "bright_blue"
 
-    def test_create_daily_table_structure(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_daily_table_structure(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test creation of daily table structure."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
 
@@ -181,7 +189,12 @@ class TestTableViewsController:
         assert table.columns[6].header == "Total Tokens"
         assert table.columns[7].header == "Cost (USD)"
 
-    def test_create_daily_table_data(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_daily_table_data(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test daily table data population."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
 
@@ -192,9 +205,16 @@ class TestTableViewsController:
         # Total: 4 rows
         assert table.row_count == 4
 
-    def test_create_monthly_table_structure(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_monthly_table_structure(
+        self,
+        controller: TableViewsController,
+        sample_monthly_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test creation of monthly table structure."""
-        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
+        table = controller.create_monthly_table(
+            sample_monthly_data, sample_totals, "UTC"
+        )
 
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
@@ -216,9 +236,16 @@ class TestTableViewsController:
         assert table.columns[6].header == "Total Tokens"
         assert table.columns[7].header == "Cost (USD)"
 
-    def test_create_monthly_table_data(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_monthly_table_data(
+        self,
+        controller: TableViewsController,
+        sample_monthly_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test monthly table data population."""
-        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
+        table = controller.create_monthly_table(
+            sample_monthly_data, sample_totals, "UTC"
+        )
 
         # The table should have:
         # - 2 data rows (for the 2 months)
@@ -227,7 +254,9 @@ class TestTableViewsController:
         # Total: 4 rows
         assert table.row_count == 4
 
-    def test_create_summary_panel(self, controller: TableViewsController, sample_totals: Dict[str, Any]) -> None:
+    def test_create_summary_panel(
+        self, controller: TableViewsController, sample_totals: Dict[str, Any]
+    ) -> None:
         """Test creation of summary panel."""
         panel = controller.create_summary_panel("daily", sample_totals, "Last 30 days")
 
@@ -245,7 +274,9 @@ class TestTableViewsController:
 
     def test_format_models_multiple(self, controller: TableViewsController) -> None:
         """Test formatting multiple models."""
-        result = controller._format_models(["claude-3-haiku", "claude-3-sonnet", "claude-3-opus"])
+        result = controller._format_models(
+            ["claude-3-haiku", "claude-3-sonnet", "claude-3-opus"]
+        )
         expected = "• claude-3-haiku\n• claude-3-sonnet\n• claude-3-opus"
         assert result == expected
 
@@ -265,33 +296,70 @@ class TestTableViewsController:
         assert panel.expand is True
         assert panel.height == 10
 
-    def test_create_aggregate_table_daily(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_aggregate_table_daily(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test create_aggregate_table for daily view."""
-        table = controller.create_aggregate_table(sample_daily_data, sample_totals, "daily", "UTC")
+        table = controller.create_aggregate_table(
+            sample_daily_data, sample_totals, "daily", "UTC"
+        )
 
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Daily (UTC)"
 
-    def test_create_aggregate_table_monthly(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_aggregate_table_monthly(
+        self,
+        controller: TableViewsController,
+        sample_monthly_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test create_aggregate_table for monthly view."""
-        table = controller.create_aggregate_table(sample_monthly_data, sample_totals, "monthly", "UTC")
+        table = controller.create_aggregate_table(
+            sample_monthly_data, sample_totals, "monthly", "UTC"
+        )
 
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
 
-    def test_create_aggregate_table_invalid_view_type(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_create_aggregate_table_invalid_view_type(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test create_aggregate_table with invalid view type."""
         with pytest.raises(ValueError, match="Invalid view type"):
-            controller.create_aggregate_table(sample_daily_data, sample_totals, "weekly", "UTC")
+            controller.create_aggregate_table(
+                sample_daily_data, sample_totals, "weekly", "UTC"
+            )
 
-    def test_daily_table_timezone_display(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_daily_table_timezone_display(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test daily table displays correct timezone."""
-        table = controller.create_daily_table(sample_daily_data, sample_totals, "America/New_York")
-        assert table.title == "Claude Code Token Usage Report - Daily (America/New_York)"
+        table = controller.create_daily_table(
+            sample_daily_data, sample_totals, "America/New_York"
+        )
+        assert (
+            table.title == "Claude Code Token Usage Report - Daily (America/New_York)"
+        )
 
-    def test_monthly_table_timezone_display(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_monthly_table_timezone_display(
+        self,
+        controller: TableViewsController,
+        sample_monthly_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test monthly table displays correct timezone."""
-        table = controller.create_monthly_table(sample_monthly_data, sample_totals, "Europe/London")
+        table = controller.create_monthly_table(
+            sample_monthly_data, sample_totals, "Europe/London"
+        )
         assert table.title == "Claude Code Token Usage Report - Monthly (Europe/London)"
 
     def test_table_with_zero_tokens(self, controller: TableViewsController) -> None:
@@ -328,7 +396,9 @@ class TestTableViewsController:
         # Note: Rich table doesn't count empty separator as a row in some versions
         assert table.row_count in [3, 4]  # Allow for version differences
 
-    def test_summary_panel_different_periods(self, controller: TableViewsController, sample_totals: Dict[str, Any]) -> None:
+    def test_summary_panel_different_periods(
+        self, controller: TableViewsController, sample_totals: Dict[str, Any]
+    ) -> None:
         """Test summary panel with different period descriptions."""
         periods = [
             "Last 30 days",
@@ -343,14 +413,21 @@ class TestTableViewsController:
             assert isinstance(panel, Panel)
             assert panel.title == "Summary"
 
-    def test_no_data_display_different_view_types(self, controller: TableViewsController) -> None:
+    def test_no_data_display_different_view_types(
+        self, controller: TableViewsController
+    ) -> None:
         """Test no data display for different view types."""
         for view_type in ["daily", "monthly", "weekly", "yearly"]:
             panel = controller.create_no_data_display(view_type)
             assert isinstance(panel, Panel)
             assert panel.title == f"No {view_type.capitalize()} Data"
 
-    def test_number_formatting_integration(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_number_formatting_integration(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test that number formatting is integrated correctly."""
         # Test that the table can be created with real formatting functions
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
@@ -359,7 +436,12 @@ class TestTableViewsController:
         assert table is not None
         assert table.row_count >= 3  # At least data rows + separator + totals
 
-    def test_currency_formatting_integration(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_currency_formatting_integration(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test that currency formatting is integrated correctly."""
         # Test that the table can be created with real formatting functions
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
@@ -368,7 +450,12 @@ class TestTableViewsController:
         assert table is not None
         assert table.row_count >= 3  # At least data rows + separator + totals
 
-    def test_table_column_alignment(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
+    def test_table_column_alignment(
+        self,
+        controller: TableViewsController,
+        sample_daily_data: List[Dict[str, Any]],
+        sample_totals: Dict[str, Any],
+    ) -> None:
         """Test that numeric columns are right-aligned."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
 

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -1,12 +1,10 @@
 """Tests for table views module."""
 
 from typing import Any, Dict, List
-from unittest.mock import Mock
 
 import pytest
 from rich.table import Table
 from rich.panel import Panel
-from rich.text import Text
 
 from claude_monitor.ui.table_views import TableViewsController
 
@@ -162,7 +160,7 @@ class TestTableViewsController:
     def test_create_daily_table_structure(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test creation of daily table structure."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
-        
+
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Daily (UTC)"
         assert table.title_style == "bold cyan"
@@ -171,7 +169,7 @@ class TestTableViewsController:
         assert table.border_style == "bright_blue"
         assert table.expand is True
         assert table.show_lines is True
-        
+
         # Check columns
         assert len(table.columns) == 8
         assert table.columns[0].header == "Date"
@@ -186,7 +184,7 @@ class TestTableViewsController:
     def test_create_daily_table_data(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test daily table data population."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
-        
+
         # The table should have:
         # - 2 data rows (for the 2 days)
         # - 1 separator row
@@ -197,7 +195,7 @@ class TestTableViewsController:
     def test_create_monthly_table_structure(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test creation of monthly table structure."""
         table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
-        
+
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
         assert table.title_style == "bold cyan"
@@ -206,7 +204,7 @@ class TestTableViewsController:
         assert table.border_style == "bright_blue"
         assert table.expand is True
         assert table.show_lines is True
-        
+
         # Check columns
         assert len(table.columns) == 8
         assert table.columns[0].header == "Month"
@@ -221,7 +219,7 @@ class TestTableViewsController:
     def test_create_monthly_table_data(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test monthly table data population."""
         table = controller.create_monthly_table(sample_monthly_data, sample_totals, "UTC")
-        
+
         # The table should have:
         # - 2 data rows (for the 2 months)
         # - 1 separator row
@@ -232,7 +230,7 @@ class TestTableViewsController:
     def test_create_summary_panel(self, controller: TableViewsController, sample_totals: Dict[str, Any]) -> None:
         """Test creation of summary panel."""
         panel = controller.create_summary_panel("daily", sample_totals, "Last 30 days")
-        
+
         assert isinstance(panel, Panel)
         assert panel.title == "Summary"
         assert panel.title_align == "center"
@@ -259,7 +257,7 @@ class TestTableViewsController:
     def test_create_no_data_display(self, controller: TableViewsController) -> None:
         """Test creation of no data display."""
         panel = controller.create_no_data_display("daily")
-        
+
         assert isinstance(panel, Panel)
         assert panel.title == "No Daily Data"
         assert panel.title_align == "center"
@@ -270,14 +268,14 @@ class TestTableViewsController:
     def test_create_aggregate_table_daily(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test create_aggregate_table for daily view."""
         table = controller.create_aggregate_table(sample_daily_data, sample_totals, "daily", "UTC")
-        
+
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Daily (UTC)"
 
     def test_create_aggregate_table_monthly(self, controller: TableViewsController, sample_monthly_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test create_aggregate_table for monthly view."""
         table = controller.create_aggregate_table(sample_monthly_data, sample_totals, "monthly", "UTC")
-        
+
         assert isinstance(table, Table)
         assert table.title == "Claude Code Token Usage Report - Monthly (UTC)"
 
@@ -311,7 +309,7 @@ class TestTableViewsController:
                 "entries_count": 0,
             }
         ]
-        
+
         totals = {
             "input_tokens": 0,
             "output_tokens": 0,
@@ -321,11 +319,11 @@ class TestTableViewsController:
             "total_cost": 0.0,
             "entries_count": 0,
         }
-        
+
         table = controller.create_daily_table(data, totals, "UTC")
         # Table should have 3 rows:
         # - 1 data row
-        # - 1 separator row (empty)  
+        # - 1 separator row (empty)
         # - 1 totals row
         # Note: Rich table doesn't count empty separator as a row in some versions
         assert table.row_count in [3, 4]  # Allow for version differences
@@ -339,7 +337,7 @@ class TestTableViewsController:
             "Q1 2024",
             "Year to date",
         ]
-        
+
         for period in periods:
             panel = controller.create_summary_panel("daily", sample_totals, period)
             assert isinstance(panel, Panel)
@@ -356,7 +354,7 @@ class TestTableViewsController:
         """Test that number formatting is integrated correctly."""
         # Test that the table can be created with real formatting functions
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
-        
+
         # Verify table was created successfully
         assert table is not None
         assert table.row_count >= 3  # At least data rows + separator + totals
@@ -365,7 +363,7 @@ class TestTableViewsController:
         """Test that currency formatting is integrated correctly."""
         # Test that the table can be created with real formatting functions
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
-        
+
         # Verify table was created successfully
         assert table is not None
         assert table.row_count >= 3  # At least data rows + separator + totals
@@ -373,7 +371,7 @@ class TestTableViewsController:
     def test_table_column_alignment(self, controller: TableViewsController, sample_daily_data: List[Dict[str, Any]], sample_totals: Dict[str, Any]) -> None:
         """Test that numeric columns are right-aligned."""
         table = controller.create_daily_table(sample_daily_data, sample_totals, "UTC")
-        
+
         # Check that numeric columns are right-aligned
         for i in range(2, 8):  # Columns 2-7 are numeric
             assert table.columns[i].justify == "right"
@@ -389,11 +387,11 @@ class TestTableViewsController:
             "total_cost": 0.0,
             "entries_count": 0,
         }
-        
+
         # Daily table with empty data
         daily_table = controller.create_daily_table([], empty_totals, "UTC")
         assert daily_table.row_count == 2  # Separator + totals
-        
+
         # Monthly table with empty data
         monthly_table = controller.create_monthly_table([], empty_totals, "UTC")
         assert monthly_table.row_count == 2  # Separator + totals

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -1,7 +1,7 @@
 """Tests for table views module."""
 
 from typing import Any, Dict, List
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 from rich.table import Table

--- a/src/tests/test_table_views.py
+++ b/src/tests/test_table_views.py
@@ -1,11 +1,8 @@
 """Tests for table views module."""
 
-from typing import Any
-from typing import Dict
-from typing import List
+from typing import Any, Dict, List
 
 import pytest
-
 from rich.panel import Panel
 from rich.table import Table
 


### PR DESCRIPTION
<img width="1773" height="822" alt="usage_daily" src="https://github.com/user-attachments/assets/f389c0ca-3efe-4184-9845-9e4f4e06f19f" />
<img width="1769" height="554" alt="usage_monthly" src="https://github.com/user-attachments/assets/91118d56-6bd2-4d10-83a1-2327bfeb98f4" />
- Add --view parameter to CLI for selecting display mode (realtime, daily, monthly)
- Implement UsageAggregator for data aggregation by day/month
- Create TableViewsController for rendering usage tables
- Add format_number utility for formatting numbers with thousand separators
- Include comprehensive tests for new functionality

This feature allows users to view their Claude token usage aggregated by day or month, making it easier to track usage patterns over time.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added table view modes ("daily" and "monthly") to the CLI monitoring tool for aggregated usage statistics.
  * Introduced configuration options to select view modes: realtime, daily, monthly, and session.
  * Provided new UI components for displaying detailed usage summaries and tables.
  * Enhanced number formatting for clearer presentation of statistics.

* **Bug Fixes**
  * Improved persistence and validation of view mode settings across sessions.
  * Enabled clean shutdown handling in live monitoring using signal-based event waiting.

* **Tests**
  * Added comprehensive tests covering data aggregation, table views, and settings persistence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->