### PR TITLE
Fix: Handle CLI argument parsing for --plan parameter

### DIFF
--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -573,6 +573,25 @@ class TestSettings:
             assert settings.plan == "custom"
             assert settings.custom_limit_tokens is None  # Should be reset
 
+    @patch("claude_monitor.core.settings.Settings._get_system_time_format")
+    @patch("claude_monitor.core.settings.Settings._get_system_timezone")
+    def test_load_with_last_used_plan_parsing(
+        self, mock_timezone: Mock, mock_time_format: Mock
+    ) -> None:
+        """Test plan parameter is correctly parsed from CLI arguments."""
+        mock_timezone.return_value = "UTC"
+        mock_time_format.return_value = "24h"
+
+        with patch("claude_monitor.core.settings.LastUsedParams") as MockLastUsed:
+            mock_instance = Mock()
+            mock_instance.load.return_value = {}
+            MockLastUsed.return_value = mock_instance
+
+            # Test various plan values
+            for plan in ["pro", "max5", "max20"]:
+                settings = Settings.load_with_last_used(["--plan", plan])
+                assert settings.plan == plan
+
     def test_to_namespace(self) -> None:
         """Test conversion to argparse.Namespace."""
         settings = Settings(


### PR DESCRIPTION
The --plan parameter was being ignored due to disabled CLI parsing in settings_customise_sources. This fix manually parses CLI arguments in load_with_last_used method to ensure command-line parameters take effect properly.

- Parse CLI arguments manually in load_with_last_used
- Handle both value parameters and boolean flags correctly
- Add test case to verify plan parameter parsing
- Maintain backward compatibility with existing functionality

Fixes the issue where running `python3 -m claude_monitor --plan max20` would still show "custom" plan instead of "max20".

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of command-line argument parsing for settings, ensuring correct merging with previously used parameters and accurate handling of flags such as plan selection and clearing settings.

* **Tests**
  * Added tests to verify correct parsing of the plan parameter from command-line arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->