### PR TITLE
Replace custom_max with custom

### DIFF
--- a/README.md
+++ b/README.md
@@ -573,7 +573,7 @@ When using the default Pro plan:
 
 1. **Detection**: Monitor notices token usage exceeding 7,000
 2. **Analysis**: Scans previous sessions for actual limits
-3. **Switch**: Automatically changes to custom_max mode
+3. **Switch**: Automatically changes to custom mode
 4. **Notification**: Displays clear message about the change
 5. **Continuation**: Keeps monitoring with new, higher limit
 
@@ -631,10 +631,10 @@ The auto-detection system:
 
 ```bash
 # Auto-detect your highest previous usage
-claude-monitor --plan custom_max
+claude-monitor --plan custom
 
 # Monitor with custom scheduling
-claude-monitor --plan custom_max --reset-hour 6
+claude-monitor --plan custom --reset-hour 6
 ```
 
 
@@ -705,7 +705,7 @@ claude-monitor
 ```
 
 - Monitor will detect if you exceed Pro limits
-- Automatically switches to custom_max if needed
+- Automatically switches to custom if needed
 - Shows notification when switching occurs
 
 **Known Subscription Users**
@@ -721,7 +721,7 @@ claude-monitor --plan max20
 **Unknown Limits**
 ```bash
 # Auto-detect from previous usage
-claude-monitor --plan custom_max
+claude-monitor --plan custom
 ```
 
 


### PR DESCRIPTION
I think these variables are outdated since the examples don't work as custom_max, but `custom`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references from "custom_max" to "custom" in the documentation, including usage examples and instructions for automatic plan switching and custom scheduling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->