### PR TITLE
Add Nix Flake distribution support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+/result
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -216,3 +217,4 @@ logs/
 # Local linting scripts
 lint*.py
 lint*.sh
+

--- a/README.md
+++ b/README.md
@@ -172,6 +172,84 @@ pip install claude-monitor
 claude-monitor  # or cmonitor, ccmonitor for short
 ```
 
+#### Nix Flakes
+
+```bash
+# Run directly without installing
+nix run github:Maciek-roboblog/Claude-Code-Usage-Monitor
+
+# Run with arguments
+nix run github:Maciek-roboblog/Claude-Code-Usage-Monitor -- --plan pro --view realtime
+
+# Install to user profile
+nix profile install github:Maciek-roboblog/Claude-Code-Usage-Monitor
+```
+
+<details>
+<summary>Install to NixOS/Home Manager Configuration (recommended)</summary>
+
+**1. Add claude-monitor to your flake inputs:**
+```nix
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    claude-monitor = {
+      url = "github:Maciek-roboblog/Claude-Code-Usage-Monitor";
+      inputs.nixpkgs.follows = "nixpkgs"; # reduce closure size
+    };
+  };
+
+  outputs = { nixpkgs, ... } @ inputs: {
+    # Your configurations here
+  };
+}
+```
+
+**2. Configure your system:**
+
+**NixOS:**
+```nix
+# flake.nix (inside outputs)
+nixosConfigurations.your-hostname = nixpkgs.lib.nixosSystem {
+  modules = [ ./configuration.nix ];
+
+  # Add `inputs` to `specialArgs` if you haven't already
+  specialArgs = { inherit inputs; };
+};
+```
+
+```nix
+# configuration.nix
+{ inputs, pkgs, ... }: {
+  environment.systemPackages = [
+    inputs.claude-monitor.packages.${pkgs.system}.default
+  ];
+}
+```
+
+**Home Manager:**
+```nix
+# flake.nix (inside outputs)
+homeConfigurations.your-username = home-manager.lib.homeManagerConfiguration {
+  modules = [ ./home.nix ];
+
+  # Add `inputs` to `extraSpecialArgs` if you haven't already
+  extraSpecialArgs = { inherit inputs; };
+};
+```
+
+```nix
+# home.nix
+{ inputs, pkgs, ... }: {
+  home.packages = [
+    inputs.claude-monitor.packages.${pkgs.system}.default
+  ];
+}
+```
+
+After rebuilding, `claude-monitor` and aliases will be available system-wide.
+</details>
+
 
 ## 📖 Usage
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1755186698,
+        "narHash": "sha256-wNO3+Ks2jZJ4nTHMuks+cxAiVBGNuEBXsT29Bz6HASo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "fbcf476f790d8a217c3eab4e12033dc4a0f6d23c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -100,6 +100,9 @@
         # Skip tests during build (they can be run separately)
         doCheck = false;
 
+        # Ensure module imports after build
+        pythonImportsCheck = ["claude_monitor"];
+
         # Ensure the package is properly installed
         postInstall = ''
           # Verify the main entry points are available

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,224 @@
+{
+  description = "Real-time Claude Code usage monitor with predictions and warnings ";
+
+  # Usage:
+  #
+  # Run the application:
+  #   nix run github:Maciek-roboblog/Claude-Code-Usage-Monitor # anywhere
+  #   nix run . -- --help # if you have this repo cloned
+  #
+  # Install to profile:
+  #   nix profile install github:Maciek-roboblog/Claude-Code-Usage-Monitor
+  #
+  # Run with specific command:
+  #   nix run .#claude-monitor -- --plan pro --view realtime
+  #   nix run .#cmonitor -- --theme dark
+  #
+  # Development:
+  #   nix develop          # Enter dev shell with all dependencies
+  #   nix build            # Build the package
+  #   nix flake check      # Run all validation checks
+  #   nix fmt .            # Format the flake.nix
+  #
+  # Available apps:
+  #   claude-monitor (default) - Main application
+  #   claude-code-monitor      - Alternative name
+  #   cmonitor                 - Short alias
+  #   ccmonitor               - Short alias
+  #   ccm                     - Shortest alias
+  #
+  # All apps support the same command-line arguments as the Python package.
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = nixpkgs.legacyPackages.${system};
+
+      claude-monitor = pkgs.python3Packages.buildPythonApplication {
+        pname = "claude-monitor";
+        version = "3.1.0";
+        format = "pyproject";
+
+        src = ./.;
+
+        nativeBuildInputs = with pkgs.python3Packages; [
+          setuptools
+          wheel
+        ];
+
+        propagatedBuildInputs = with pkgs.python3Packages;
+          [
+            numpy
+            pydantic
+            pydantic-settings
+            pyyaml
+            pytz
+            rich
+          ]
+          ++ pkgs.lib.optionals (pkgs.python3Packages.pythonOlder "3.11") [
+            tomli
+          ]
+          ++ pkgs.lib.optionals pkgs.stdenv.hostPlatform.isWindows [
+            tzdata
+          ];
+
+        # Optional development dependencies
+        passthru.optional-dependencies = {
+          dev = with pkgs.python3Packages;
+            [
+              black
+              isort
+              mypy
+              pytest
+              pytest-asyncio
+              pytest-benchmark
+              pytest-cov
+              pytest-mock
+              pytest-xdist
+              ruff
+              build
+              twine
+            ]
+            ++ [pkgs.pre-commit];
+          test = with pkgs.python3Packages; [
+            pytest
+            pytest-cov
+            pytest-mock
+            pytest-asyncio
+            pytest-benchmark
+          ];
+        };
+
+        # Skip tests during build (they can be run separately)
+        doCheck = false;
+
+        # Ensure the package is properly installed
+        postInstall = ''
+          # Verify the main entry points are available
+          $out/bin/claude-monitor --help > /dev/null
+        '';
+
+        meta = with pkgs.lib; {
+          description = "A real-time terminal monitoring tool for Claude Code token usage with advanced analytics and Rich UI";
+          homepage = "https://github.com/Maciek-roboblog/Claude-Code-Usage-Monitor";
+          license = licenses.mit;
+          maintainers = [];
+          platforms = platforms.unix;
+          mainProgram = "claude-monitor";
+        };
+      };
+
+      # Development shell with all dependencies
+      devShell = pkgs.mkShell {
+        packages =
+          [
+            pkgs.python3
+            pkgs.python3Packages.pip
+            pkgs.python3Packages.setuptools
+            pkgs.python3Packages.wheel
+            pkgs.pre-commit
+          ]
+          ++ claude-monitor.propagatedBuildInputs
+          ++ (with pkgs.python3Packages; [
+            black
+            isort
+            mypy
+            pytest
+            pytest-asyncio
+            pytest-benchmark
+            pytest-cov
+            pytest-mock
+            pytest-xdist
+            ruff
+            build
+            twine
+          ]);
+      };
+    in {
+      packages = {
+        default = claude-monitor;
+        claude-monitor = claude-monitor;
+      };
+
+      apps = {
+        default = {
+          type = "app";
+          program = "${claude-monitor}/bin/claude-monitor";
+        };
+        claude-monitor = {
+          type = "app";
+          program = "${claude-monitor}/bin/claude-monitor";
+        };
+        claude-code-monitor = {
+          type = "app";
+          program = "${claude-monitor}/bin/claude-code-monitor";
+        };
+        cmonitor = {
+          type = "app";
+          program = "${claude-monitor}/bin/cmonitor";
+        };
+        ccmonitor = {
+          type = "app";
+          program = "${claude-monitor}/bin/ccmonitor";
+        };
+        ccm = {
+          type = "app";
+          program = "${claude-monitor}/bin/ccm";
+        };
+      };
+
+      devShells.default = devShell;
+
+      # Checks for `nix check`
+      checks = {
+        # Build test - ensures the package builds correctly
+        build = claude-monitor;
+
+        # Format check - ensures code is properly formatted
+        format-check =
+          pkgs.runCommand "format-check" {
+            buildInputs = [pkgs.alejandra];
+          } ''
+            alejandra --check ${./.}/flake.nix
+            touch $out
+          '';
+
+        # Python syntax check
+        python-syntax =
+          pkgs.runCommand "python-syntax" {
+            buildInputs = [pkgs.python3];
+          } ''
+            # Copy source to writable location to avoid permission issues
+            cp -r ${./.}/src /tmp/src
+            cd /tmp
+
+            # Check Python syntax
+            python3 -c "import ast; ast.parse(open('src/claude_monitor/__main__.py').read())"
+            python3 -c "import ast; ast.parse(open('src/claude_monitor/__init__.py').read())"
+
+            touch $out
+          '';
+
+        # Package installation test
+        install-test =
+          pkgs.runCommand "install-test" {
+            buildInputs = [claude-monitor];
+          } ''
+            claude-monitor --version
+            claude-monitor --help > /dev/null
+            touch $out
+          '';
+      };
+
+      # Formatter for `nix fmt .`
+      formatter = pkgs.alejandra;
+    });
+}


### PR DESCRIPTION
## Summary

This PR adds comprehensive Nix Flake support for the Claude Monitor package, enabling easy installation and usage on NixOS and other Nix-based systems.

You can test the functionality before approving by running it from my repo:

```sh
nix run github:aster-void/Claude-Code-Usage-Monitor?ref=add-nix-flake-distribution
```

## Changes

### 🎯 Core Features
- **Complete Nix Flake definition** with Python package and all dependencies
- **Multiple app aliases** for convenience: `claude-monitor`, `claude-code-monitor`, `cmonitor`, `ccmonitor`, `ccm`
- **Development shell** with all dev dependencies (pytest, black, ruff, mypy, etc.)
- **Cross-platform support** with conditional dependencies for Linux/macOS

### 📚 Documentation
- **Nix installation section** added to README.md with usage examples
- **NixOS and Home Manager configuration** examples in collapsible sections
- **Complete flake usage documentation** in the flake comments
- **Proper flake structure** examples with inputs and outputs

### ✅ Quality & Validation
- **`nix flake check`** validates build, formatting, syntax, and installation
- **Automated formatting** with Alejandra
- **Python syntax validation** for core files
- **Installation verification** tests

## Usage Examples

```bash
# Run directly without installation
nix run github:Maciek-roboblog/Claude-Code-Usage-Monitor

# Run with arguments
nix run github:Maciek-roboblog/Claude-Code-Usage-Monitor -- --plan pro --view realtime

# Install to user profile
nix profile install github:Maciek-roboblog/Claude-Code-Usage-Monitor

# Development shell
nix develop github:Maciek-roboblog/Claude-Code-Usage-Monitor
```

## System Configuration

For NixOS/Home Manager users, the package can be added to system configurations:

<details>
<summary>Configuration Examples</summary>

**Flake inputs:**
```nix
{
  inputs = {
    claude-monitor = {
      url = "github:Maciek-roboblog/Claude-Code-Usage-Monitor";
      inputs.nixpkgs.follows = "nixpkgs";
    };
  };
}
```

**NixOS:**
```nix
environment.systemPackages = [
  inputs.claude-monitor.packages.${pkgs.system}.default
];
```

**Home Manager:**
```nix
home.packages = [
  inputs.claude-monitor.packages.${pkgs.system}.default
];
```
</details>

## Test plan

- [x] `nix flake check` passes all validation
- [x] `nix build` successfully builds the package
- [x] `nix run` executes the application correctly
- [x] All app aliases work as expected
- [x] Development shell includes all necessary dependencies
- [x] Installation verification tests pass
- [x] Documentation is clear and comprehensive

## Benefits

- **Easy installation** for Nix users without Python environment setup
- **Reproducible builds** with pinned dependencies
- **System integration** via NixOS/Home Manager configurations
- **Developer-friendly** with complete dev environment
- **Quality assurance** with automated validation

This makes the Claude Monitor easily accessible to the growing Nix ecosystem while maintaining all existing functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added Nix Flakes support to build, run, and install the CLI with multiple app aliases (claude-monitor, claude-code-monitor, cmonitor, ccmonitor, ccm) and packaged release metadata.

- Documentation
  - Added Nix Flakes installation and usage guides, including run/install instructions and NixOS/Home Manager configuration examples (duplicated in two spots).

- Chores
  - Excluded the result directory from version control.
  - Added flake-based checks, a formatter, and a developer shell to streamline development and testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->