### PR TITLE
Fix: Add missing quotes to pip install

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ source venv/bin/activate  # Linux/Mac
 # venv\Scripts\activate   # Windows
 
 # Install project and development dependencies
-pip install -e .[dev]
+pip install -e '.[dev]'   # Linux/Mac
 
 # Make script executable (Linux/Mac)
 chmod +x claude_monitor.py


### PR DESCRIPTION
This is a pretty simple PR. On `bash`, I needed quotes for the `pip install` (otherwise it's an expression that matches the files `.d`, `.e`, or `.v`. I couldn't test it on Windows, however, so I added a comment marking this as a Linux/Mac.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated development setup instructions to use a quoted extras spec in the pip install command (pip install -e '.[dev]') to prevent shell globbing.
  * Added a brief note for Linux/Mac shells.
  * No changes to code, APIs, or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->