### PR TITLE
Add weekly quota tracking with rolling 7-day window

### DIFF
--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -19,7 +19,13 @@ from claude_monitor.cli.bootstrap import (
     setup_environment,
     setup_logging,
 )
-from claude_monitor.core.plans import Plans, PlanType, get_token_limit
+from claude_monitor.core.plans import (
+    Plans,
+    PlanType,
+    get_token_limit,
+    get_weekly_token_limit,
+    get_weekly_cost_limit,
+)
 from claude_monitor.core.settings import Settings
 from claude_monitor.data.aggregator import UsageAggregator
 from claude_monitor.data.analysis import analyze_usage
@@ -130,7 +136,7 @@ def _run_monitoring(args: argparse.Namespace) -> None:
         logger.info(f"Using data path: {data_path}")
 
         # Handle different view modes
-        if view_mode in ["daily", "monthly"]:
+        if view_mode in ["daily", "weekly", "monthly"]:
             _run_table_view(args, data_path, view_mode, console)
             return
 
@@ -381,7 +387,7 @@ def validate_cli_environment() -> Optional[str]:
 def _run_table_view(
     args: argparse.Namespace, data_path: Path, view_mode: str, console: Console
 ) -> None:
-    """Run table view mode (daily/monthly)."""
+    """Run table view mode (daily/weekly/monthly)."""
     logger = logging.getLogger(__name__)
 
     try:
@@ -403,6 +409,21 @@ def _run_table_view(
             print_themed(f"No usage data found for {view_mode} view", style="warning")
             return
 
+        # For weekly view, also calculate rolling 7-day quota usage
+        weekly_usage = None
+        if view_mode == "weekly":
+            from claude_monitor.data.reader import load_usage_entries
+
+            entries, _ = load_usage_entries(data_path=str(data_path))
+            if entries:
+                weekly_token_limit = get_weekly_token_limit(args.plan)
+                weekly_cost_limit = get_weekly_cost_limit(args.plan)
+                weekly_usage = aggregator.aggregate_rolling_week(
+                    entries,
+                    token_limit=weekly_token_limit,
+                    cost_limit=weekly_cost_limit,
+                )
+
         # Display the table
         controller.display_aggregated_view(
             data=aggregated_data,
@@ -410,6 +431,7 @@ def _run_table_view(
             timezone=args.timezone,
             plan=args.plan,
             token_limit=_get_initial_token_limit(args, data_path),
+            weekly_usage=weekly_usage,
         )
 
         # Wait for user to press Ctrl+C

--- a/src/claude_monitor/core/models.py
+++ b/src/claude_monitor/core/models.py
@@ -69,6 +69,49 @@ class UsageProjection:
 
 
 @dataclass
+class WeeklyUsage:
+    """Rolling 7-day weekly usage tracking for quota monitoring."""
+
+    week_start: datetime
+    week_end: datetime
+    tokens_used: int = 0
+    cost_used: float = 0.0
+    token_limit: int = 0
+    cost_limit: float = 0.0
+    days_elapsed: float = 0.0
+    per_model_tokens: Dict[str, int] = field(default_factory=dict)
+
+    @property
+    def tokens_remaining(self) -> int:
+        """Tokens remaining in weekly quota."""
+        return max(0, self.token_limit - self.tokens_used)
+
+    @property
+    def usage_percentage(self) -> float:
+        """Percentage of weekly quota used."""
+        if self.token_limit <= 0:
+            return 0.0
+        return min(100.0, (self.tokens_used / self.token_limit) * 100)
+
+    @property
+    def days_remaining(self) -> float:
+        """Days remaining in rolling 7-day window."""
+        return max(0.0, 7.0 - self.days_elapsed)
+
+    @property
+    def daily_burn_rate(self) -> float:
+        """Average tokens per day based on current usage."""
+        if self.days_elapsed <= 0:
+            return 0.0
+        return self.tokens_used / self.days_elapsed
+
+    @property
+    def projected_weekly_total(self) -> int:
+        """Projected total tokens at end of week based on current burn rate."""
+        return int(self.tokens_used + (self.daily_burn_rate * self.days_remaining))
+
+
+@dataclass
 class SessionBlock:
     """Aggregated session block representing a 5-hour period."""
 

--- a/src/claude_monitor/core/plans.py
+++ b/src/claude_monitor/core/plans.py
@@ -35,6 +35,8 @@ class PlanConfig:
     cost_limit: float
     message_limit: int
     display_name: str
+    weekly_token_limit: int = 0
+    weekly_cost_limit: float = 0.0
 
     @property
     def formatted_token_limit(self) -> str:
@@ -43,6 +45,17 @@ class PlanConfig:
             return f"{self.token_limit // 1_000}k"
         return str(self.token_limit)
 
+    @property
+    def formatted_weekly_token_limit(self) -> str:
+        """Human-readable weekly token limit (e.g., '2.3B' or '500M')."""
+        if self.weekly_token_limit >= 1_000_000_000:
+            return f"{self.weekly_token_limit / 1_000_000_000:.1f}B"
+        if self.weekly_token_limit >= 1_000_000:
+            return f"{self.weekly_token_limit / 1_000_000:.0f}M"
+        if self.weekly_token_limit >= 1_000:
+            return f"{self.weekly_token_limit // 1_000}k"
+        return str(self.weekly_token_limit)
+
 
 PLAN_LIMITS: Dict[PlanType, Dict[str, Any]] = {
     PlanType.PRO: {
@@ -50,24 +63,36 @@ PLAN_LIMITS: Dict[PlanType, Dict[str, Any]] = {
         "cost_limit": 18.0,
         "message_limit": 250,
         "display_name": "Pro",
+        # Pro has limited weekly capacity (no separate weekly limit published)
+        "weekly_token_limit": 500_000_000,  # ~500M estimated
+        "weekly_cost_limit": 400.0,
     },
     PlanType.MAX5: {
         "token_limit": 88_000,
         "cost_limit": 35.0,
         "message_limit": 1_000,
         "display_name": "Max5",
+        # Max5: ~5x Pro capacity, estimated 1.2B weekly
+        "weekly_token_limit": 1_200_000_000,
+        "weekly_cost_limit": 800.0,
     },
     PlanType.MAX20: {
         "token_limit": 220_000,
         "cost_limit": 140.0,
         "message_limit": 2_000,
         "display_name": "Max20",
+        # Max20: ~8x the 5-hour block limit (~290M) = ~2.3B weekly
+        "weekly_token_limit": 2_300_000_000,
+        "weekly_cost_limit": 1600.0,
     },
     PlanType.CUSTOM: {
         "token_limit": 44_000,
         "cost_limit": 50.0,
         "message_limit": 250,
         "display_name": "Custom",
+        # Custom: P90-based, default to Pro-like weekly
+        "weekly_token_limit": 500_000_000,
+        "weekly_cost_limit": 400.0,
     },
 }
 
@@ -97,6 +122,8 @@ class Plans:
             cost_limit=data["cost_limit"],
             message_limit=data["message_limit"],
             display_name=data["display_name"],
+            weekly_token_limit=data.get("weekly_token_limit", 0),
+            weekly_cost_limit=data.get("weekly_cost_limit", 0.0),
         )
 
     @classmethod
@@ -201,3 +228,29 @@ def get_cost_limit(plan: str) -> float:
         Cost limit for the plan in USD
     """
     return Plans.get_cost_limit(plan)
+
+
+def get_weekly_token_limit(plan: str) -> int:
+    """Get weekly rolling token limit for a plan.
+
+    Args:
+        plan: Plan type ('pro', 'max5', 'max20', 'custom')
+
+    Returns:
+        Weekly token limit for the plan
+    """
+    cfg = Plans.get_plan_by_name(plan)
+    return cfg.weekly_token_limit if cfg else 500_000_000
+
+
+def get_weekly_cost_limit(plan: str) -> float:
+    """Get weekly rolling cost limit for a plan.
+
+    Args:
+        plan: Plan type ('pro', 'max5', 'max20', 'custom')
+
+    Returns:
+        Weekly cost limit for the plan in USD
+    """
+    cfg = Plans.get_plan_by_name(plan)
+    return cfg.weekly_cost_limit if cfg else 400.0

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -104,9 +104,9 @@ class Settings(BaseSettings):
         description="Plan type (pro, max5, max20, custom)",
     )
 
-    view: Literal["realtime", "daily", "monthly", "session"] = Field(
+    view: Literal["realtime", "daily", "weekly", "monthly", "session"] = Field(
         default="realtime",
-        description="View mode (realtime, daily, monthly, session)",
+        description="View mode (realtime, daily, weekly, monthly, session)",
     )
 
     @staticmethod
@@ -190,7 +190,7 @@ class Settings(BaseSettings):
         """Validate and normalize view value."""
         if isinstance(v, str):
             v_lower = v.lower()
-            valid_views = ["realtime", "daily", "monthly", "session"]
+            valid_views = ["realtime", "daily", "weekly", "monthly", "session"]
             if v_lower in valid_views:
                 return v_lower
             raise ValueError(

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -1,16 +1,22 @@
-"""Data aggregator for daily and monthly statistics.
+"""Data aggregator for daily, weekly, and monthly statistics.
 
 This module provides functionality to aggregate Claude usage data
-by day and month, similar to ccusage's functionality.
+by day, week, and month, similar to ccusage's functionality.
+Includes rolling 7-day aggregation for weekly quota tracking.
 """
 
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from typing import Any, Callable, Dict, List, Optional
 
-from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
+from claude_monitor.core.models import (
+    SessionBlock,
+    UsageEntry,
+    WeeklyUsage,
+    normalize_model_name,
+)
 from claude_monitor.utils.time_utils import TimezoneHandler
 
 logger = logging.getLogger(__name__)
@@ -202,6 +208,100 @@ class UsageAggregator:
             end_date,
         )
 
+    def aggregate_weekly(
+        self,
+        entries: List[UsageEntry],
+        start_date: Optional[datetime] = None,
+        end_date: Optional[datetime] = None,
+    ) -> List[Dict[str, Any]]:
+        """Aggregate usage data by ISO week (Monday-Sunday).
+
+        Args:
+            entries: List of usage entries
+            start_date: Optional start date filter
+            end_date: Optional end date filter
+
+        Returns:
+            List of weekly aggregated data
+        """
+
+        def get_week_key(timestamp: datetime) -> str:
+            # ISO week format: YYYY-Www (e.g., 2025-W03)
+            iso_year, iso_week, _ = timestamp.isocalendar()
+            return f"{iso_year}-W{iso_week:02d}"
+
+        return self._aggregate_by_period(
+            entries,
+            get_week_key,
+            "week",
+            start_date,
+            end_date,
+        )
+
+    def aggregate_rolling_week(
+        self,
+        entries: List[UsageEntry],
+        token_limit: int = 0,
+        cost_limit: float = 0.0,
+    ) -> WeeklyUsage:
+        """Aggregate usage for the rolling 7-day window (quota tracking).
+
+        This calculates usage for the past 7 days from now, which is how
+        Claude's weekly quota system works (rolling window, not calendar week).
+
+        Args:
+            entries: List of usage entries
+            token_limit: Weekly token limit for the plan
+            cost_limit: Weekly cost limit for the plan
+
+        Returns:
+            WeeklyUsage object with quota tracking data
+        """
+        now = datetime.now(timezone.utc)
+        week_start = now - timedelta(days=7)
+        week_end = now
+
+        # Filter entries to last 7 days
+        weekly_entries = [
+            e for e in entries if week_start <= e.timestamp <= week_end
+        ]
+
+        # Calculate totals
+        total_tokens = 0
+        total_cost = 0.0
+        per_model_tokens: Dict[str, int] = defaultdict(int)
+
+        for entry in weekly_entries:
+            entry_tokens = (
+                entry.input_tokens
+                + entry.output_tokens
+                + entry.cache_creation_tokens
+                + entry.cache_read_tokens
+            )
+            total_tokens += entry_tokens
+            total_cost += entry.cost_usd
+
+            model = normalize_model_name(entry.model) if entry.model else "unknown"
+            per_model_tokens[model] += entry_tokens
+
+        # Calculate days elapsed (from first entry to now, capped at 7)
+        if weekly_entries:
+            earliest = min(e.timestamp for e in weekly_entries)
+            days_elapsed = min(7.0, (now - earliest).total_seconds() / 86400)
+        else:
+            days_elapsed = 0.0
+
+        return WeeklyUsage(
+            week_start=week_start,
+            week_end=week_end,
+            tokens_used=total_tokens,
+            cost_used=total_cost,
+            token_limit=token_limit,
+            cost_limit=cost_limit,
+            days_elapsed=days_elapsed,
+            per_model_tokens=dict(per_model_tokens),
+        )
+
     def aggregate_from_blocks(
         self, blocks: List[SessionBlock], view_type: str = "daily"
     ) -> List[Dict[str, Any]]:
@@ -209,15 +309,15 @@ class UsageAggregator:
 
         Args:
             blocks: List of session blocks
-            view_type: Type of aggregation ('daily' or 'monthly')
+            view_type: Type of aggregation ('daily', 'weekly', or 'monthly')
 
         Returns:
             List of aggregated data
         """
         # Validate view type
-        if view_type not in ["daily", "monthly"]:
+        if view_type not in ["daily", "weekly", "monthly"]:
             raise ValueError(
-                f"Invalid view type: {view_type}. Must be 'daily' or 'monthly'"
+                f"Invalid view type: {view_type}. Must be 'daily', 'weekly', or 'monthly'"
             )
 
         # Extract all entries from blocks
@@ -229,6 +329,8 @@ class UsageAggregator:
         # Aggregate based on view type
         if view_type == "daily":
             return self.aggregate_daily(all_entries)
+        elif view_type == "weekly":
+            return self.aggregate_weekly(all_entries)
         else:
             return self.aggregate_monthly(all_entries)
 
@@ -291,6 +393,8 @@ class UsageAggregator:
         # Aggregate based on mode
         if self.aggregation_mode == "daily":
             return self.aggregate_daily(entries)
+        elif self.aggregation_mode == "weekly":
+            return self.aggregate_weekly(entries)
         elif self.aggregation_mode == "monthly":
             return self.aggregate_monthly(entries)
         else:

--- a/src/claude_monitor/ui/table_views.py
+++ b/src/claude_monitor/ui/table_views.py
@@ -1,7 +1,7 @@
-"""Table views for daily and monthly statistics display.
+"""Table views for daily, weekly, and monthly statistics display.
 
 This module provides UI components for displaying aggregated usage data
-in table format using Rich library.
+in table format using Rich library, including weekly quota tracking.
 """
 
 import logging
@@ -10,10 +10,11 @@ from typing import Any, Dict, List, Optional, Union
 from rich.align import Align
 from rich.console import Console
 from rich.panel import Panel
+from rich.progress import BarColumn, Progress, TextColumn
 from rich.table import Table
 from rich.text import Text
 
-# Removed theme import - using direct styles
+from claude_monitor.core.models import WeeklyUsage
 from claude_monitor.utils.formatting import format_currency, format_number
 
 logger = logging.getLogger(__name__)
@@ -200,6 +201,182 @@ class TableViewsController:
 
         return table
 
+    def create_weekly_table(
+        self,
+        weekly_data: List[Dict[str, Any]],
+        totals: Dict[str, Any],
+        timezone: str = "UTC",
+    ) -> Table:
+        """Create a weekly statistics table (ISO weeks).
+
+        Args:
+            weekly_data: List of weekly aggregated data
+            totals: Total statistics
+            timezone: Timezone for display
+
+        Returns:
+            Rich Table object
+        """
+        # Create base table
+        table = self._create_base_table(
+            title=f"Claude Code Token Usage Report - Weekly ({timezone})",
+            period_column_name="Week",
+            period_column_width=12,
+        )
+
+        # Add data rows
+        self._add_data_rows(table, weekly_data, "week")
+
+        # Add totals
+        self._add_totals_row(table, totals)
+
+        return table
+
+    def create_weekly_quota_panel(
+        self,
+        weekly_usage: WeeklyUsage,
+        plan_name: str = "custom",
+    ) -> Panel:
+        """Create a panel showing rolling 7-day weekly quota usage.
+
+        Args:
+            weekly_usage: WeeklyUsage data object
+            plan_name: Name of the plan for display
+
+        Returns:
+            Rich Panel object with quota visualization
+        """
+        lines = []
+
+        # Header
+        lines.append(
+            Text("📅 Rolling 7-Day Weekly Quota", style="bold cyan")
+        )
+        lines.append(Text(""))
+
+        # Progress bar visualization
+        pct = weekly_usage.usage_percentage
+        bar_width = 30
+        filled = int(bar_width * min(pct, 100) / 100)
+        empty = bar_width - filled
+
+        # Color based on usage level
+        if pct < 50:
+            bar_color = "green"
+        elif pct < 80:
+            bar_color = "yellow"
+        else:
+            bar_color = "red"
+
+        bar = Text()
+        bar.append("   ")
+        bar.append("█" * filled, style=bar_color)
+        bar.append("░" * empty, style="dim")
+        bar.append(f" {pct:.1f}%", style=bar_color)
+        lines.append(bar)
+        lines.append(Text(""))
+
+        # Token stats
+        def format_tokens(n: int) -> str:
+            if n >= 1_000_000_000:
+                return f"{n / 1_000_000_000:.1f}B"
+            if n >= 1_000_000:
+                return f"{n / 1_000_000:.1f}M"
+            if n >= 1_000:
+                return f"{n / 1_000:.0f}K"
+            return str(n)
+
+        lines.append(
+            Text(
+                f"   Used: {format_tokens(weekly_usage.tokens_used)} / "
+                f"{format_tokens(weekly_usage.token_limit)} tokens",
+                style=self.value_style,
+            )
+        )
+        lines.append(
+            Text(
+                f"   Remaining: {format_tokens(weekly_usage.tokens_remaining)}",
+                style=self.success_style,
+            )
+        )
+        lines.append(
+            Text(
+                f"   Cost: {format_currency(weekly_usage.cost_used)}",
+                style=self.value_style,
+            )
+        )
+        lines.append(Text(""))
+
+        # Burn rate and projections
+        if weekly_usage.daily_burn_rate > 0:
+            lines.append(Text("📊 Burn Rate", style="bold cyan"))
+            lines.append(
+                Text(
+                    f"   {format_tokens(int(weekly_usage.daily_burn_rate))}/day",
+                    style=self.value_style,
+                )
+            )
+            lines.append(
+                Text(
+                    f"   Projected weekly: {format_tokens(weekly_usage.projected_weekly_total)}",
+                    style=self.accent_style,
+                )
+            )
+            lines.append(Text(""))
+
+        # Model breakdown
+        if weekly_usage.per_model_tokens:
+            lines.append(Text("🤖 By Model", style="bold cyan"))
+            total = weekly_usage.tokens_used or 1
+            for model, tokens in sorted(
+                weekly_usage.per_model_tokens.items(),
+                key=lambda x: x[1],
+                reverse=True,
+            ):
+                model_pct = (tokens / total) * 100
+                # Shorten model name
+                short_name = model.replace("claude-", "").replace("-20", "")
+                lines.append(
+                    Text(
+                        f"   {short_name}: {format_tokens(tokens)} ({model_pct:.0f}%)",
+                        style=self.value_style,
+                    )
+                )
+            lines.append(Text(""))
+
+        # Warnings
+        if pct >= 80:
+            lines.append(
+                Text(
+                    "⚠️  Approaching weekly limit! Consider using Haiku for lighter tasks.",
+                    style="yellow",
+                )
+            )
+        elif pct >= 100:
+            lines.append(
+                Text(
+                    "🚨 Weekly quota exceeded - expect rate limiting",
+                    style="red bold",
+                )
+            )
+
+        # Combine all lines
+        content = Text()
+        for line in lines:
+            content.append(line)
+            content.append("\n")
+
+        panel = Panel(
+            content,
+            title=f"Weekly Quota ({plan_name.upper()})",
+            title_align="left",
+            border_style=self.border_style,
+            expand=True,
+            padding=(1, 2),
+        )
+
+        return panel
+
     def create_summary_panel(
         self, view_type: str, totals: Dict[str, Any], period: str
     ) -> Panel:
@@ -294,22 +471,24 @@ class TableViewsController:
         view_type: str,
         timezone: str = "UTC",
     ) -> Table:
-        """Create a table for either daily or monthly aggregated data.
+        """Create a table for aggregated data (daily, weekly, or monthly).
 
         Args:
-            aggregate_data: List of aggregated data (daily or monthly)
+            aggregate_data: List of aggregated data
             totals: Total statistics
-            view_type: Type of view ('daily' or 'monthly')
+            view_type: Type of view ('daily', 'weekly', or 'monthly')
             timezone: Timezone for display
 
         Returns:
             Rich Table object
 
         Raises:
-            ValueError: If view_type is not 'daily' or 'monthly'
+            ValueError: If view_type is not valid
         """
         if view_type == "daily":
             return self.create_daily_table(aggregate_data, totals, timezone)
+        elif view_type == "weekly":
+            return self.create_weekly_table(aggregate_data, totals, timezone)
         elif view_type == "monthly":
             return self.create_monthly_table(aggregate_data, totals, timezone)
         else:
@@ -323,16 +502,18 @@ class TableViewsController:
         plan: str,
         token_limit: int,
         console: Optional[Console] = None,
+        weekly_usage: Optional[WeeklyUsage] = None,
     ) -> None:
         """Display aggregated view with table and summary.
 
         Args:
             data: Aggregated data
-            view_mode: View type ('daily' or 'monthly')
+            view_mode: View type ('daily', 'weekly', or 'monthly')
             timezone: Timezone string
             plan: Plan type
             token_limit: Token limit for the plan
             console: Optional Console instance
+            weekly_usage: Optional WeeklyUsage for quota panel (weekly view)
         """
         if not data:
             no_data_display = self.create_no_data_display(view_mode)
@@ -362,8 +543,21 @@ class TableViewsController:
         # Determine period for summary
         if view_mode == "daily":
             period = f"{data[0]['date']} to {data[-1]['date']}" if data else "No data"
+        elif view_mode == "weekly":
+            period = f"{data[0]['week']} to {data[-1]['week']}" if data else "No data"
         else:  # monthly
             period = f"{data[0]['month']} to {data[-1]['month']}" if data else "No data"
+
+        # For weekly view, show quota panel first if available
+        if view_mode == "weekly" and weekly_usage:
+            quota_panel = self.create_weekly_quota_panel(weekly_usage, plan)
+            if console:
+                console.print(quota_panel)
+                console.print()
+            else:
+                from rich import print as rprint
+                rprint(quota_panel)
+                rprint()
 
         # Create and display summary panel
         summary_panel = self.create_summary_panel(view_mode, totals, period)


### PR DESCRIPTION
## Summary

This PR adds support for tracking weekly token usage against Claude's rolling 7-day quota limits. This helps users understand their quota consumption and avoid hitting limits.

### Features

- **WeeklyUsage model** - New data model for tracking weekly quota (tokens used, cost, burn rate, per-model breakdown)
- **Weekly token/cost limits per plan** - Estimated limits for Pro (~500M), Max5 (~1.2B), Max20 (~2.3B)
- **Rolling 7-day aggregation** - Separate from calendar week view, matching Claude's actual quota system
- **New `--view weekly` CLI option** - Shows weekly statistics with quota panel
- **Weekly quota panel** - Progress bar, remaining tokens, daily burn rate, and weekly projections
- **Per-model token breakdown** - See which models are consuming quota

### Usage

```bash
# View weekly quota status
claude-monitor --view weekly --plan max20

# The output includes:
# - Rolling 7-day quota progress bar
# - Tokens used vs limit
# - Daily burn rate and weekly projection
# - Per-model breakdown (opus, sonnet, haiku)
```

### Why Rolling 7-Day?

Claude's weekly quota uses a rolling window where usage from exactly 7 days ago "expires," making room for new capacity. This is different from calendar weeks - there's no single "reset day."

This implementation tracks the rolling 7-day window to accurately represent your quota consumption.

## Test plan

- [ ] Run `claude-monitor --view weekly --plan max20` and verify quota panel displays
- [ ] Verify weekly table shows ISO week groupings
- [ ] Test with different plans (pro, max5, max20, custom)
- [ ] Verify burn rate and projection calculations are reasonable

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added weekly view mode for monitoring rolling 7-day usage and quota tracking alongside existing daily and monthly views.
  * Weekly quota visualization displays token/cost metrics, daily burn rate, per-model breakdown, and remaining quota.
  * Includes projected weekly totals and warning indicators for quota management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->