### PR TITLE
feat: add write_state_file functionality for external integrations

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ claude-monitor --help
 | --log-level | string | INFO | Logging level: DEBUG, INFO, WARNING, ERROR, CRITICAL |
 | --log-file | path | None | Log file path |
 | --debug | flag | False | Enable debug logging |
+| --write-state | flag | False | Write current state to JSON file for external tools (see [STATE_FILE.md](STATE_FILE.md)) |
 | --version, -v | flag | False | Show version information |
 | --clear | flag | False | Clear saved configuration |
 
@@ -231,6 +232,7 @@ The monitor automatically saves your preferences to avoid re-specifying them on 
 - Refresh rates (--refresh-rate, --refresh-per-second)
 - Reset hour (--reset-hour)
 - Custom token limits (--custom-limit-tokens)
+- State file writing (--write-state)
 
 **Configuration Location:** ~/.claude-monitor/last_used.json
 
@@ -693,6 +695,41 @@ claude-monitor --view daily --timezone America/New_York
 - **Daily**: Analyze daily consumption patterns and identify peak usage days
 - **Monthly**: Long-term trend analysis and monthly budget planning
 
+#### 🔌 External Tool Integration
+
+**Scenario**: Building VS Code extensions, status bar widgets, or other tools that need real-time usage data.
+
+```bash
+# Enable state file writing for external consumption
+claude-monitor --write-state
+
+# With custom refresh rate (updates every 5 seconds)
+claude-monitor --write-state --refresh-rate 5
+
+# State file persists - run once and it remembers
+claude-monitor --write-state  # Enable once
+claude-monitor                # Runs with --write-state enabled
+```
+
+**State File Location**: `~/.claude-monitor/reports/current.json`
+
+**What You Get**:
+
+- Real-time messages, tokens, and cost usage
+- Limit tracking (used/limit/percent)
+- Reset countdown timer
+- Token burn rate
+- JSON format for easy parsing
+
+**Perfect For**:
+
+- VS Code status bar extensions
+- Desktop notification systems
+- Custom dashboards and widgets
+- Integration with other dev tools
+
+📖 **Full Documentation**: See [STATE_FILE.md](STATE_FILE.md) for complete JSON schema, TypeScript/Python types, and integration examples.
+
 
 ### Plan Selection Strategies
 
@@ -1153,6 +1190,7 @@ Whether you need help with setup, have feature requests, found a bug, or want to
 
 ## 📚 Additional Documentation
 
+- **[State File Documentation](STATE_FILE.md)** - JSON state file format for external integrations (VS Code extensions, status bars, etc.)
 - **[Development Roadmap](DEVELOPMENT.md)** - ML features, PyPI package, Docker plans
 - **[Contributing Guide](CONTRIBUTING.md)** - How to contribute, development guidelines
 - **[Troubleshooting](TROUBLESHOOTING.md)** - Common issues and solutions

--- a/STATE_FILE.md
+++ b/STATE_FILE.md
@@ -1,0 +1,441 @@
+# State File Documentation
+
+## Overview
+
+When the `--write-state` flag is enabled, Claude Monitor writes real-time usage statistics to a JSON file that can be consumed by external applications (VS Code extensions, status bar widgets, etc.).
+
+**File Location**: `~/.claude-monitor/reports/current.json`
+
+**Environment Variable**: `CLAUDE_MONITOR_REPORT_DIR` (set by bootstrap.py)
+
+**Update Frequency**: Updates every `--refresh-rate` seconds (default: 10 seconds) when an active Claude session is detected.
+
+## File Structure
+
+```json
+{
+  "messages": {
+    "used": 140,
+    "limit": 250,
+    "percent": 56.0
+  },
+  "tokens": {
+    "used": 17582,
+    "limit": 38705,
+    "percent": 45.43
+  },
+  "cost": {
+    "used": 5.125579,
+    "limit": 50.0,
+    "percent": 10.25
+  },
+  "reset": {
+    "timestamp": "2026-01-10T00:00:00+00:00",
+    "secondsRemaining": 19777,
+    "formattedTime": "12:00 AM"
+  },
+  "burnRate": {
+    "tokens": 32859.04,
+    "messages": 0
+  },
+  "lastUpdate": "2026-01-09T13:30:22.976757"
+}
+```
+
+## Field Descriptions
+
+### `messages`
+Message count statistics for the current session window.
+
+- **`used`** (integer): Number of messages sent in the current session window
+- **`limit`** (integer): Maximum messages allowed before reset
+  - For standard plans (Pro/Max20): Fixed plan limit
+  - For custom plans: P90 (90th percentile) calculated from usage history
+  - May be `0` if insufficient history for P90 calculation
+- **`percent`** (float): Percentage of limit used (0-100+)
+
+### `tokens`
+Token usage statistics for the current session window.
+
+- **`used`** (integer): Total tokens consumed (input + output + cache tokens)
+- **`limit`** (integer): Maximum tokens allowed before reset
+  - For standard plans: Fixed plan limit
+  - For custom plans: P90 calculated from usage history
+- **`percent`** (float): Percentage of limit used (0-100+)
+
+### `cost`
+Cost statistics in USD for the current session window.
+
+- **`used`** (float): Total cost in USD for all API calls
+- **`limit`** (float): Maximum cost before reset
+  - For standard plans: Fixed plan limit
+  - For custom plans: P90 calculated from usage history
+- **`percent`** (float): Percentage of limit used (0-100+)
+
+### `reset`
+Information about when usage counters reset.
+
+- **`timestamp`** (string): ISO 8601 formatted UTC timestamp of next reset
+  - Example: `"2026-01-10T00:00:00+00:00"`
+- **`secondsRemaining`** (integer): Seconds until reset occurs
+  - Useful for countdown timers
+- **`formattedTime`** (string): Human-readable 12-hour time format
+  - Example: `"12:00 AM"`
+  - Timezone-aware based on `--timezone` setting
+
+### `burnRate`
+Current consumption rate based on last hour of activity.
+
+- **`tokens`** (float): Tokens consumed per minute (averaged over last hour)
+  - Calculated by `calculate_hourly_burn_rate()` in `core/calculations.py`
+  - Returns `0.0` if no activity in last hour
+- **`messages`** (integer): Currently always `0` (messages burn rate not yet implemented)
+
+### `lastUpdate`
+- **`lastUpdate`** (string): ISO 8601 timestamp when this file was last written
+  - Example: `"2026-01-09T13:30:22.976757"`
+  - Useful for detecting stale data
+
+## Type Definitions
+
+### TypeScript
+
+```typescript
+interface ClaudeMonitorState {
+  messages: UsageMetric;
+  tokens: UsageMetric;
+  cost: UsageMetric;
+  reset: ResetInfo;
+  burnRate: BurnRate;
+  lastUpdate: string; // ISO 8601 timestamp
+}
+
+interface UsageMetric {
+  used: number;
+  limit: number;
+  percent: number;
+}
+
+interface ResetInfo {
+  timestamp: string; // ISO 8601 UTC timestamp
+  secondsRemaining: number;
+  formattedTime: string; // "HH:MM AM/PM"
+}
+
+interface BurnRate {
+  tokens: number; // tokens per minute
+  messages: number; // currently always 0
+}
+```
+
+### Python
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypedDict
+
+class UsageMetric(TypedDict):
+    used: int | float
+    limit: int | float
+    percent: float
+
+class ResetInfo(TypedDict):
+    timestamp: str  # ISO 8601 UTC
+    secondsRemaining: int
+    formattedTime: str
+
+class BurnRate(TypedDict):
+    tokens: float
+    messages: int
+
+class ClaudeMonitorState(TypedDict):
+    messages: UsageMetric
+    tokens: UsageMetric
+    cost: UsageMetric
+    reset: ResetInfo
+    burnRate: BurnRate
+    lastUpdate: str  # ISO 8601
+```
+
+## Usage Examples
+
+### Python Example: File Watching
+
+```python
+import json
+import time
+from pathlib import Path
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+
+STATE_FILE = Path.home() / ".claude-monitor" / "reports" / "current.json"
+
+class StateFileHandler(FileSystemEventHandler):
+    def on_modified(self, event):
+        if event.src_path == str(STATE_FILE):
+            with open(STATE_FILE) as f:
+                state = json.load(f)
+                print(f"Messages: {state['messages']['used']}/{state['messages']['limit']}")
+                print(f"Reset in: {state['reset']['secondsRemaining']}s")
+
+observer = Observer()
+observer.schedule(StateFileHandler(), str(STATE_FILE.parent), recursive=False)
+observer.start()
+
+try:
+    while True:
+        time.sleep(1)
+except KeyboardInterrupt:
+    observer.stop()
+observer.join()
+```
+
+### TypeScript Example: VS Code Extension
+
+```typescript
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as os from 'os';
+
+const STATE_FILE = path.join(os.homedir(), '.claude-monitor', 'reports', 'current.json');
+
+export function activate(context: vscode.ExtensionContext) {
+    const statusBarItem = vscode.window.createStatusBarItem(
+        vscode.StatusBarAlignment.Right,
+        100
+    );
+
+    // Watch for file changes
+    const watcher = fs.watch(STATE_FILE, (eventType) => {
+        if (eventType === 'change') {
+            updateStatusBar(statusBarItem);
+        }
+    });
+
+    // Initial update
+    updateStatusBar(statusBarItem);
+    statusBarItem.show();
+
+    context.subscriptions.push(statusBarItem);
+    context.subscriptions.push({ dispose: () => watcher.close() });
+}
+
+function updateStatusBar(statusBarItem: vscode.StatusBarItem) {
+    try {
+        const data = fs.readFileSync(STATE_FILE, 'utf8');
+        const state: ClaudeMonitorState = JSON.parse(data);
+
+        // Check if data is stale (> 30 seconds old)
+        const lastUpdate = new Date(state.lastUpdate);
+        const age = Date.now() - lastUpdate.getTime();
+        if (age > 30000) {
+            statusBarItem.text = "$(circle-slash) Claude: No active session";
+            return;
+        }
+
+        // Format countdown timer
+        const hours = Math.floor(state.reset.secondsRemaining / 3600);
+        const minutes = Math.floor((state.reset.secondsRemaining % 3600) / 60);
+        const timeLeft = `${hours}h ${minutes}m`;
+
+        // Show messages and reset time
+        statusBarItem.text = `$(comment) ${state.messages.used}/${state.messages.limit} | $(clock) ${timeLeft}`;
+        statusBarItem.tooltip = `Tokens: ${state.tokens.used}/${state.tokens.limit}\nCost: $${state.cost.used.toFixed(2)}/$${state.cost.limit}\nResets at: ${state.reset.formattedTime}`;
+    } catch (error) {
+        statusBarItem.text = "$(circle-slash) Claude: Monitor not running";
+    }
+}
+```
+
+### Node.js Example: Simple Reader
+
+```javascript
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const STATE_FILE = path.join(os.homedir(), '.claude-monitor', 'reports', 'current.json');
+
+function readState() {
+    try {
+        const data = fs.readFileSync(STATE_FILE, 'utf8');
+        return JSON.parse(data);
+    } catch (error) {
+        console.error('Failed to read state file:', error.message);
+        return null;
+    }
+}
+
+function formatCountdown(seconds) {
+    const hours = Math.floor(seconds / 3600);
+    const minutes = Math.floor((seconds % 3600) / 60);
+    const secs = seconds % 60;
+    return `${hours}h ${minutes}m ${secs}s`;
+}
+
+// Read and display current state
+const state = readState();
+if (state) {
+    console.log(`Messages: ${state.messages.used}/${state.messages.limit} (${state.messages.percent.toFixed(1)}%)`);
+    console.log(`Tokens: ${state.tokens.used}/${state.tokens.limit} (${state.tokens.percent.toFixed(1)}%)`);
+    console.log(`Cost: $${state.cost.used.toFixed(2)}/$${state.cost.limit} (${state.cost.percent.toFixed(1)}%)`);
+    console.log(`Reset in: ${formatCountdown(state.reset.secondsRemaining)}`);
+    console.log(`Burn rate: ${state.burnRate.tokens.toFixed(1)} tokens/min`);
+}
+```
+
+## Best Practices
+
+### File Watching
+
+1. **Use native file watchers** instead of polling for better performance
+   - Python: `watchdog` library
+   - Node.js: `fs.watch()` or `chokidar`
+   - Go: `fsnotify`
+
+2. **Debounce updates** to avoid excessive redraws (100-500ms recommended)
+
+3. **Check `lastUpdate` timestamp** to detect stale data
+   - If `lastUpdate` is > 30 seconds old, assume monitor is not running
+   - If `lastUpdate` is > 2 × `refresh_rate`, assume monitor crashed
+
+### Error Handling
+
+1. **File may not exist** if:
+   - Monitor has never been run with `--write-state`
+   - No active Claude session has occurred yet
+   - User cleared the reports directory
+
+2. **File may be empty or invalid JSON** during write operations
+   - Catch JSON parse errors gracefully
+   - Consider using file locking or atomic reads if critical
+
+3. **Permissions** - File is created with user permissions (0644)
+
+### Data Interpretation
+
+1. **Limits may be 0** for custom plans with insufficient history
+   - Check if `limit === 0` before calculating percentages
+   - Show "Calculating..." or "N/A" in UI
+
+2. **Percentages can exceed 100%** if user goes over their limit
+   - Handle gracefully in UI (show warning color, etc.)
+
+3. **Reset time is timezone-aware**
+   - `timestamp` is always UTC
+   - `formattedTime` uses user's `--timezone` setting (default: America/New_York)
+
+4. **Burn rate reflects last hour**
+   - May be 0 if no activity in last 60 minutes
+   - Not predictive, purely historical
+
+## Configuration
+
+### Enable State File Writing
+
+```bash
+# Enable state file writing
+claude-monitor --write-state
+
+# With custom refresh rate (updates every 5 seconds)
+claude-monitor --write-state --refresh-rate 5
+
+# Settings persist across sessions
+claude-monitor --write-state  # Run once
+claude-monitor                # Will remember --write-state flag
+```
+
+### Disable State File Writing
+
+```bash
+# Disable by not passing the flag
+claude-monitor
+
+# Or explicitly clear saved settings
+claude-monitor --clear
+```
+
+### Environment Variables
+
+The state file location can be customized via environment variable:
+
+```bash
+export CLAUDE_MONITOR_REPORT_DIR="/custom/path/to/reports"
+claude-monitor --write-state
+```
+
+Default: `~/.claude-monitor/reports/`
+
+## Technical Details
+
+### Update Mechanism
+
+1. **Data Flow**:
+   ```
+   MonitoringOrchestrator (every --refresh-rate seconds)
+   → on_data_update callback
+   → DisplayController.create_data_display()
+   → _write_state_file() [if write_state_enabled]
+   ```
+
+2. **Only updates when there's an active session**
+   - File is NOT updated if no Claude activity detected
+   - Check `lastUpdate` to determine if session is active
+
+3. **Atomic writes**: File is written atomically using `Path.write_text()`
+   - No partial writes under normal conditions
+   - No file locking required for readers
+
+### Data Sources
+
+- **Messages/Tokens/Cost**: Calculated from session blocks in `~/.claude/projects/`
+- **Limits**:
+  - Standard plans: Fixed values from `core/plans.py`
+  - Custom plans: P90 calculated from historical usage via `P90Calculator`
+- **Reset time**: Based on `--reset-hour` setting (default: 0 = midnight UTC)
+- **Burn rate**: Calculated by `calculate_hourly_burn_rate()` from last hour of activity
+
+### File Format
+
+- **Encoding**: UTF-8
+- **Indentation**: 2 spaces
+- **Line endings**: Platform-specific (LF on Unix, CRLF on Windows)
+- **File size**: Typically < 500 bytes
+
+## Troubleshooting
+
+### File Not Created
+
+- Ensure `--write-state` flag is enabled
+- Check that monitor is running with an active Claude session
+- Verify permissions on `~/.claude-monitor/reports/` directory
+
+### Stale Data
+
+- Check monitor is still running: `ps aux | grep claude-monitor`
+- Verify `lastUpdate` timestamp is recent
+- Check logs: `~/.claude-monitor/logs/debug.log`
+
+### Invalid JSON
+
+- File may be mid-write when read (very rare with atomic writes)
+- Retry read after brief delay (10-50ms)
+- Check disk space and permissions
+
+### Wrong Limits
+
+- For custom plans, P90 requires sufficient history (typically 10+ sessions)
+- Limits show `0` if insufficient data - this is expected behavior
+- Standard plans (pro/max20) always have fixed non-zero limits
+
+## Related Documentation
+
+- [Main README](README.md) - Installation and basic usage
+- [DEVELOPMENT.md](DEVELOPMENT.md) - Development setup
+- [TROUBLESHOOTING.md](TROUBLESHOOTING.md) - Common issues
+
+## Version History
+
+- **v3.1.0** (2026-01-09): Initial state file feature with `--write-state` flag

--- a/STATE_FILE.md
+++ b/STATE_FILE.md
@@ -373,7 +373,8 @@ Default: `~/.claude-monitor/reports/`
 ### Update Mechanism
 
 1. **Data Flow**:
-   ```
+
+   ```text
    MonitoringOrchestrator (every --refresh-rate seconds)
    → on_data_update callback
    → DisplayController.create_data_display()
@@ -384,8 +385,8 @@ Default: `~/.claude-monitor/reports/`
    - File is NOT updated if no Claude activity detected
    - Check `lastUpdate` to determine if session is active
 
-3. **Atomic writes**: File is written atomically using `Path.write_text()`
-   - No partial writes under normal conditions
+3. **File writes**: File is written using `Path.write_text()`
+   - Typically completes without partial writes under normal conditions
    - No file locking required for readers
 
 ### Data Sources

--- a/STATE_FILE.md
+++ b/STATE_FILE.md
@@ -325,7 +325,7 @@ if (state) {
 
 3. **Reset time is timezone-aware**
    - `timestamp` is always UTC
-   - `formattedTime` uses user's `--timezone` setting (default: America/New_York)
+   - `formattedTime` uses user's `--timezone` setting (default: Europe/Warsaw)
 
 4. **Burn rate reflects last hour**
    - May be 0 if no activity in last 60 minutes
@@ -394,7 +394,7 @@ Default: `~/.claude-monitor/reports/`
 - **Limits**:
   - Standard plans: Fixed values from `core/plans.py`
   - Custom plans: P90 calculated from historical usage via `P90Calculator`
-- **Reset time**: Based on `--reset-hour` setting (default: 0 = midnight UTC)
+- **Reset time**: Extracted from session `end_time_str` in processed_data (not from `--reset-hour` setting)
 - **Burn rate**: Calculated by `calculate_hourly_burn_rate()` from last hour of activity
 
 ### File Format

--- a/src/claude_monitor/cli/bootstrap.py
+++ b/src/claude_monitor/cli/bootstrap.py
@@ -50,6 +50,9 @@ def setup_environment() -> None:
     os.environ.setdefault(
         "CLAUDE_MONITOR_CACHE_DIR", str(Path.home() / ".claude-monitor" / "cache")
     )
+    os.environ.setdefault(
+        "CLAUDE_MONITOR_REPORT_DIR", str(Path.home() / ".claude-monitor" / "reports")
+    )
 
 
 def init_timezone(timezone: str = "Europe/Warsaw") -> TimezoneHandler:

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -138,6 +138,7 @@ def _run_monitoring(args: argparse.Namespace) -> None:
 
         display_controller = DisplayController()
         display_controller.live_manager._console = console
+        display_controller.write_state_enabled = getattr(args, 'write_state', False)
 
         refresh_per_second: float = getattr(args, "refresh_per_second", 0.75)
         logger.info(

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -34,6 +34,7 @@ class LastUsedParams:
                 "refresh_rate": settings.refresh_rate,
                 "reset_hour": settings.reset_hour,
                 "view": settings.view,
+                "write_state": settings.write_state,
                 "timestamp": datetime.now().isoformat(),
             }
 
@@ -169,6 +170,11 @@ class Settings(BaseSettings):
     version: bool = Field(default=False, description="Show version information")
 
     clear: bool = Field(default=False, description="Clear saved configuration")
+
+    write_state: bool = Field(
+        default=False,
+        description="Write current state to reports/current.json for external consumers",
+    )
 
     @field_validator("plan", mode="before")
     @classmethod
@@ -350,5 +356,6 @@ class Settings(BaseSettings):
         args.log_level = self.log_level
         args.log_file = str(self.log_file) if self.log_file else None
         args.version = self.version
+        args.write_state = self.write_state
 
         return args

--- a/src/claude_monitor/ui/display_controller.py
+++ b/src/claude_monitor/ui/display_controller.py
@@ -389,7 +389,7 @@ class DisplayController:
                     'tokens': round(token_burn_rate, 2),
                     'messages': 0
                 },
-                'lastUpdate': datetime.now().isoformat()
+                'lastUpdate': datetime.now(timezone.utc).isoformat()
             }
 
             # Write to file

--- a/src/claude_monitor/ui/display_controller.py
+++ b/src/claude_monitor/ui/display_controller.py
@@ -316,11 +316,6 @@ class DisplayController:
             args: Command line arguments
         """
         try:
-            import json
-            import os
-            from datetime import timedelta
-            from pathlib import Path as PathLib
-
             # Extract values from processed_data
             tokens_used = processed_data.get("tokens_used", 0)
             token_limit = processed_data.get("token_limit", 0)
@@ -393,7 +388,11 @@ class DisplayController:
             }
 
             # Write to file
-            state_file = PathLib(os.environ["CLAUDE_MONITOR_REPORT_DIR"]) / 'current.json'
+            report_dir = os.environ.get(
+                "CLAUDE_MONITOR_REPORT_DIR",
+                str(Path.home() / ".claude-monitor" / "reports")
+            )
+            state_file = Path(report_dir) / 'current.json'
             state_file.write_text(json.dumps(state, indent=2))
 
         except Exception as e:

--- a/src/claude_monitor/ui/display_controller.py
+++ b/src/claude_monitor/ui/display_controller.py
@@ -334,8 +334,8 @@ class DisplayController:
             messages_limit = processed_data.get("messages_limit_p90", 0)
             messages_percent = (messages_used / messages_limit * 100) if messages_limit > 0 else 0
 
-            burn_rate = processed_data.get("burn_rate", {})
-            token_burn_rate = burn_rate.get("tokens_per_minute", 0) if burn_rate else 0
+            # burn_rate is a float (tokens per minute) from calculate_hourly_burn_rate()
+            token_burn_rate = processed_data.get("burn_rate", 0.0)
 
             # Calculate reset time
             reset_hour = getattr(args, 'reset_hour', None) or 0
@@ -379,6 +379,7 @@ class DisplayController:
             state_file.write_text(json.dumps(state, indent=2))
 
         except Exception as e:
+            logger = logging.getLogger(__name__)
             logger.error(f"Failed to write state file: {e}", exc_info=True)
 
     def _process_active_session_data(

--- a/src/tests/test_write_state_file.py
+++ b/src/tests/test_write_state_file.py
@@ -1,0 +1,1381 @@
+"""Comprehensive tests for write_state_file functionality."""
+
+import json
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict
+from unittest.mock import Mock, patch
+
+import pytest
+
+from claude_monitor.ui.display_controller import DisplayController
+
+
+class TestWriteStateFile:
+    """Test suite for state file writing functionality."""
+
+    @pytest.fixture
+    def controller(self) -> DisplayController:
+        """Create DisplayController instance with write_state enabled."""
+        with patch("claude_monitor.ui.display_controller.NotificationManager"):
+            controller = DisplayController()
+            controller.write_state_enabled = True
+            return controller
+
+    @pytest.fixture
+    def temp_report_dir(self, tmp_path: Path) -> Path:
+        """Create temporary report directory."""
+        report_dir = tmp_path / "reports"
+        report_dir.mkdir()
+        return report_dir
+
+    @pytest.fixture
+    def sample_processed_data(self) -> Dict[str, Any]:
+        """Sample processed data for testing."""
+        return {
+            "tokens_used": 15000,
+            "token_limit": 50000,
+            "usage_percentage": 30.0,
+            "session_cost": 2.5,
+            "cost_limit_p90": 10.0,
+            "sent_messages": 25,
+            "messages_limit_p90": 100,
+            "burn_rate": 150.5,
+            "reset_time": datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc),
+        }
+
+    @pytest.fixture
+    def sample_args(self) -> Mock:
+        """Sample CLI arguments."""
+        args = Mock()
+        args.timezone = "UTC"
+        args.time_format = "24h"
+        return args
+
+    # ========================================================================
+    # A. BASIC FUNCTIONALITY TESTS (10 tests)
+    # ========================================================================
+
+    def test_state_file_created_when_enabled(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file is created when write_state_enabled is True."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+
+    def test_state_file_not_created_when_disabled(
+        self,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file is NOT created when write_state_enabled is False."""
+        with patch("claude_monitor.ui.display_controller.NotificationManager"):
+            controller = DisplayController()
+            controller.write_state_enabled = False
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # This should not create the file
+            # Note: The method won't even be called if write_state_enabled is False
+            # in the actual implementation, but we test the flag here
+            state_file = temp_report_dir / "current.json"
+            assert not state_file.exists()
+
+    def test_state_file_location_correct(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test file location is $CLAUDE_MONITOR_REPORT_DIR/current.json."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            expected_path = temp_report_dir / "current.json"
+            assert expected_path.exists()
+            assert expected_path.name == "current.json"
+
+    def test_state_file_contains_valid_json(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file contains valid JSON."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)  # Should not raise
+                assert isinstance(data, dict)
+
+    def test_state_file_has_all_required_top_level_fields(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file contains all required top-level fields."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            required_fields = [
+                "messages",
+                "tokens",
+                "cost",
+                "reset",
+                "burnRate",
+                "lastUpdate",
+            ]
+            for field in required_fields:
+                assert field in data, f"Missing required field: {field}"
+
+    def test_state_file_has_all_nested_fields(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file contains all nested fields."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Check nested fields
+            assert all(k in data["messages"] for k in ["used", "limit", "percent"])
+            assert all(k in data["tokens"] for k in ["used", "limit", "percent"])
+            assert all(k in data["cost"] for k in ["used", "limit", "percent"])
+            assert all(
+                k in data["reset"]
+                for k in ["timestamp", "secondsRemaining", "formattedTime"]
+            )
+            assert all(k in data["burnRate"] for k in ["tokens", "messages"])
+
+    def test_state_file_data_types_correct(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test data types are correct (int, float, string, nested objects)."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Integer fields
+            assert isinstance(data["messages"]["used"], int)
+            assert isinstance(data["messages"]["limit"], int)
+            assert isinstance(data["tokens"]["used"], int)
+            assert isinstance(data["tokens"]["limit"], int)
+            assert isinstance(data["reset"]["secondsRemaining"], int)
+
+            # Float fields
+            assert isinstance(data["messages"]["percent"], (int, float))
+            assert isinstance(data["tokens"]["percent"], (int, float))
+            assert isinstance(data["cost"]["used"], (int, float))
+            assert isinstance(data["cost"]["limit"], (int, float))
+            assert isinstance(data["cost"]["percent"], (int, float))
+            assert isinstance(data["burnRate"]["tokens"], (int, float))
+
+            # String fields
+            assert isinstance(data["reset"]["timestamp"], str)
+            assert isinstance(data["reset"]["formattedTime"], str)
+            assert isinstance(data["lastUpdate"], str)
+
+    def test_state_file_overwrites_on_each_update(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test file overwrites on each update."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # First write
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data1 = json.load(f)
+
+            # Modify data and write again
+            sample_processed_data["tokens_used"] = 20000
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            with open(state_file) as f:
+                data2 = json.load(f)
+
+            assert data2["tokens"]["used"] == 20000
+            assert data2["tokens"]["used"] != data1["tokens"]["used"]
+
+    def test_state_file_readable_permissions(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test file permissions are appropriate (readable)."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+            assert os.access(state_file, os.R_OK)
+
+    def test_state_file_written_atomically(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test file is written atomically (using Path.write_text)."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # The implementation uses Path.write_text which is atomic
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            # File should exist and be complete
+            with open(state_file) as f:
+                data = json.load(f)  # Should parse without error
+                assert "messages" in data
+
+    # ========================================================================
+    # B. DATA ACCURACY TESTS (12 tests)
+    # ========================================================================
+
+    def test_token_percentage_calculated_correctly(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test token percentage calculated correctly: (used/limit)*100."""
+        sample_processed_data["tokens_used"] = 15000
+        sample_processed_data["token_limit"] = 50000
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            expected_percent = (15000 / 50000) * 100
+            assert data["tokens"]["percent"] == round(expected_percent, 2)
+
+    def test_cost_percentage_calculated_correctly(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test cost percentage calculated correctly: (used/limit)*100."""
+        sample_processed_data["session_cost"] = 2.5
+        sample_processed_data["cost_limit_p90"] = 10.0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            expected_percent = (2.5 / 10.0) * 100
+            assert data["cost"]["percent"] == round(expected_percent, 2)
+
+    def test_messages_percentage_calculated_correctly(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test messages percentage calculated correctly: (used/limit)*100."""
+        sample_processed_data["sent_messages"] = 25
+        sample_processed_data["messages_limit_p90"] = 100
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            expected_percent = (25 / 100) * 100
+            assert data["messages"]["percent"] == round(expected_percent, 2)
+
+    def test_burn_rate_is_float(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test burn_rate field is float (regression test for d8933e5)."""
+        sample_processed_data["burn_rate"] = 150.5
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert isinstance(data["burnRate"]["tokens"], (int, float))
+            assert data["burnRate"]["tokens"] == 150.5
+
+    def test_burn_rate_value_from_processed_data(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test burn_rate value matches processed_data."""
+        test_burn_rate = 1234.56
+        sample_processed_data["burn_rate"] = test_burn_rate
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["burnRate"]["tokens"] == round(test_burn_rate, 2)
+
+    def test_reset_time_from_processed_data(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time comes from processed_data (not recalculated)."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["reset"]["timestamp"] == reset_time.isoformat()
+
+    def test_seconds_remaining_calculated_correctly(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test secondsRemaining calculated correctly from current time."""
+        reset_time = datetime.now(timezone.utc) + timedelta(hours=2)
+        sample_processed_data["reset_time"] = reset_time
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should be approximately 2 hours (7200 seconds) ± a few seconds
+            assert 7190 < data["reset"]["secondsRemaining"] < 7210
+
+    def test_formatted_time_respects_timezone(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test formattedTime respects user's timezone setting."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "America/New_York"  # UTC-5 or UTC-4 depending on DST
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # 18:00 UTC = 13:00 EST (or 14:00 EDT depending on DST)
+            # Just verify it's NOT 18:00 (i.e., timezone conversion happened)
+            formatted = data["reset"]["formattedTime"]
+            assert "18:00" not in formatted
+            assert "13:00" in formatted or "14:00" in formatted
+
+    def test_formatted_time_respects_time_format_24h(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test formattedTime respects 24h time format."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "UTC"
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should be 18:00 in 24h format
+            assert "18:00" in data["reset"]["formattedTime"]
+
+    def test_timestamp_is_iso8601_format(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test timestamp is ISO 8601 format."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should be parseable as ISO 8601
+            timestamp = data["reset"]["timestamp"]
+            parsed = datetime.fromisoformat(timestamp.replace("+00:00", "+00:00"))
+            assert parsed.tzinfo is not None
+
+    def test_last_update_is_recent(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test lastUpdate is recent (within test execution time)."""
+        before_time = (
+            datetime.now()
+        )  # Use local time since write_state_file uses datetime.now()
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+        after_time = datetime.now()  # Use local time
+
+        state_file = temp_report_dir / "current.json"
+        with open(state_file) as f:
+            data = json.load(f)
+
+        last_update = datetime.fromisoformat(data["lastUpdate"])
+        # Make timezone-naive for comparison if needed
+        if last_update.tzinfo is not None:
+            last_update = last_update.replace(tzinfo=None)
+        if before_time.tzinfo is not None:
+            before_time = before_time.replace(tzinfo=None)
+        if after_time.tzinfo is not None:
+            after_time = after_time.replace(tzinfo=None)
+
+        assert before_time <= last_update <= after_time
+
+    def test_percentage_values_rounded_to_2_decimals(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test all percentage values rounded to 2 decimal places."""
+        # Use values that will produce many decimal places
+        sample_processed_data["tokens_used"] = 12345
+        sample_processed_data["token_limit"] = 67890
+        sample_processed_data["session_cost"] = 1.23456
+        sample_processed_data["cost_limit_p90"] = 7.89012
+        sample_processed_data["sent_messages"] = 33
+        sample_processed_data["messages_limit_p90"] = 77
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Check that percentages have at most 2 decimal places
+            assert len(str(data["tokens"]["percent"]).split(".")[-1]) <= 2
+            assert len(str(data["cost"]["percent"]).split(".")[-1]) <= 2
+            assert len(str(data["messages"]["percent"]).split(".")[-1]) <= 2
+
+    # ========================================================================
+    # C. RESET TIME CALCULATION TESTS (8 tests) - Critical for 06e880f fix
+    # ========================================================================
+
+    def test_reset_time_uses_processed_data_not_manual_calculation(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time uses processed_data['reset_time'] not manual calculation."""
+        # Set a specific reset time that wouldn't match reset_hour calculation
+        specific_reset = datetime(2026, 1, 11, 15, 30, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = specific_reset
+        sample_args.reset_hour = 0  # Different from 15
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should match processed_data reset time, not reset_hour
+            assert data["reset"]["timestamp"] == specific_reset.isoformat()
+
+    def test_reset_time_is_timezone_aware(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time is timezone-aware (UTC)."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should include timezone info (+00:00 for UTC)
+            assert "+00:00" in data["reset"]["timestamp"]
+
+    def test_reset_time_converted_to_user_timezone_for_formatted_time(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time converted to user's timezone for formattedTime."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "Europe/Warsaw"  # UTC+1
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # 18:00 UTC = 19:00 Warsaw time
+            assert "19:00" in data["reset"]["formattedTime"]
+
+    def test_seconds_remaining_decreases_over_time(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test secondsRemaining decreases over time."""
+        reset_time = datetime.now(timezone.utc) + timedelta(hours=1)
+        sample_processed_data["reset_time"] = reset_time
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # First write
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data1 = json.load(f)
+
+            # Wait a bit and write again
+            import time
+
+            time.sleep(1)
+
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            with open(state_file) as f:
+                data2 = json.load(f)
+
+            # Second write should have fewer seconds remaining
+            assert (
+                data2["reset"]["secondsRemaining"] <= data1["reset"]["secondsRemaining"]
+            )
+
+    def test_reset_time_timezone_conversion_europe_warsaw(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time handles timezone conversion (UTC → Europe/Warsaw)."""
+        reset_time = datetime(2026, 1, 10, 23, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "Europe/Warsaw"  # UTC+1
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # 23:00 UTC = 00:00 next day Warsaw time
+            # Could be either depending on DST
+            formatted = data["reset"]["formattedTime"]
+            assert "00:00" in formatted or "23:00" in formatted
+
+    def test_reset_time_timezone_conversion_us_pacific(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test reset time handles timezone conversion (UTC → US/Pacific)."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "US/Pacific"  # UTC-8
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # 18:00 UTC = 10:00 PST
+            assert "10:00" in data["reset"]["formattedTime"]
+
+    def test_formatted_time_format_matches_time_format_preference_12h(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test formatted time format matches time_format preference (12h)."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "UTC"
+        sample_args.time_format = "12h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should include AM/PM
+            formatted = data["reset"]["formattedTime"]
+            assert "AM" in formatted or "PM" in formatted
+
+    def test_formatted_time_format_matches_time_format_preference_24h(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test formatted time format matches time_format preference (24h)."""
+        reset_time = datetime(2026, 1, 10, 18, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+        sample_args.timezone = "UTC"
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should NOT include AM/PM
+            formatted = data["reset"]["formattedTime"]
+            assert "AM" not in formatted and "PM" not in formatted
+            assert "18:00" in formatted
+
+    # ========================================================================
+    # D. EDGE CASES TESTS (12 tests)
+    # ========================================================================
+
+    def test_behavior_when_reset_time_is_none(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when reset_time is None (should skip write)."""
+        sample_processed_data["reset_time"] = None
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Should return early without creating file
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert not state_file.exists()
+
+    def test_behavior_when_cost_limit_is_zero(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when cost_limit is 0 (avoid division by zero)."""
+        sample_processed_data["cost_limit_p90"] = 0
+        sample_processed_data["session_cost"] = 5.0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should handle gracefully (percent = 0)
+            assert data["cost"]["percent"] == 0
+
+    def test_behavior_when_messages_limit_is_zero(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when messages_limit is 0 (avoid division by zero)."""
+        sample_processed_data["messages_limit_p90"] = 0
+        sample_processed_data["sent_messages"] = 25
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should handle gracefully (percent = 0)
+            assert data["messages"]["percent"] == 0
+
+    def test_behavior_when_percentages_exceed_100(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when percentages exceed 100%."""
+        sample_processed_data["tokens_used"] = 75000
+        sample_processed_data["token_limit"] = 50000  # Used exceeds limit
+        sample_processed_data["usage_percentage"] = 150.0  # Update this too
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should allow percentages > 100
+            # Note: Implementation uses usage_percentage from processed_data
+            assert data["tokens"]["percent"] == 150.0
+
+    def test_behavior_with_pro_plan(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior with pro plan type."""
+        sample_args.plan = "pro"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+
+    def test_behavior_with_max5_plan(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior with max5 plan type."""
+        sample_args.plan = "max5"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+
+    def test_behavior_with_custom_plan(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior with custom plan type."""
+        sample_args.plan = "custom"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+
+    def test_behavior_with_various_timezones(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior with various timezone values."""
+        timezones = ["UTC", "America/New_York", "Europe/London", "Asia/Tokyo"]
+
+        for tz in timezones:
+            sample_args.timezone = tz
+
+            with patch.dict(
+                os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+            ):
+                controller._write_state_file(sample_processed_data, sample_args)
+
+                state_file = temp_report_dir / "current.json"
+                assert state_file.exists()
+
+    def test_behavior_with_12h_time_format(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior with 12h time format."""
+        sample_args.time_format = "12h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should include AM or PM
+            assert (
+                "AM" in data["reset"]["formattedTime"]
+                or "PM" in data["reset"]["formattedTime"]
+            )
+
+    def test_behavior_when_burn_rate_is_zero(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when burn_rate is 0."""
+        sample_processed_data["burn_rate"] = 0.0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["burnRate"]["tokens"] == 0.0
+
+    def test_behavior_when_all_usage_is_zero(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when all usage is 0."""
+        sample_processed_data["tokens_used"] = 0
+        sample_processed_data["session_cost"] = 0.0
+        sample_processed_data["sent_messages"] = 0
+        sample_processed_data["burn_rate"] = 0.0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["tokens"]["used"] == 0
+            assert data["cost"]["used"] == 0.0
+            assert data["messages"]["used"] == 0
+            assert data["burnRate"]["tokens"] == 0.0
+
+    def test_behavior_with_limits_zero_insufficient_history(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test behavior when limits are 0 (custom plan, insufficient history)."""
+        sample_processed_data["token_limit"] = 0
+        sample_processed_data["cost_limit_p90"] = 0
+        sample_processed_data["messages_limit_p90"] = 0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # Should handle gracefully
+            assert data["tokens"]["limit"] == 0
+            assert data["cost"]["limit"] == 0
+            assert data["messages"]["limit"] == 0
+
+    # ========================================================================
+    # E. ERROR HANDLING TESTS (8 tests)
+    # ========================================================================
+
+    def test_graceful_failure_when_directory_doesnt_exist(
+        self,
+        controller: DisplayController,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test graceful failure when directory doesn't exist."""
+        nonexistent_dir = "/nonexistent/directory/that/should/not/exist"
+
+        with patch.dict(os.environ, {"CLAUDE_MONITOR_REPORT_DIR": nonexistent_dir}):
+            # Should not raise exception
+            try:
+                controller._write_state_file(sample_processed_data, sample_args)
+            except Exception:
+                # Should handle gracefully
+                pass
+
+    def test_graceful_failure_on_permission_errors(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test graceful failure on permission errors."""
+        # Make directory read-only
+        temp_report_dir.chmod(0o444)
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Should not raise exception
+            try:
+                controller._write_state_file(sample_processed_data, sample_args)
+            except Exception:
+                pass
+
+        # Restore permissions for cleanup
+        temp_report_dir.chmod(0o755)
+
+    def test_graceful_failure_when_env_var_not_set(
+        self,
+        controller: DisplayController,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test graceful failure when environment variable not set."""
+        # Remove the environment variable
+        with patch.dict(os.environ, {}, clear=True):
+            # Should not raise exception
+            try:
+                controller._write_state_file(sample_processed_data, sample_args)
+            except Exception:
+                pass
+
+    def test_logger_called_on_errors(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test logger is called on errors."""
+        # Make directory read-only to trigger error
+        temp_report_dir.chmod(0o444)
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            with patch("logging.getLogger") as mock_logger:
+                mock_log_instance = Mock()
+                mock_logger.return_value = mock_log_instance
+
+                try:
+                    controller._write_state_file(sample_processed_data, sample_args)
+                except Exception:
+                    pass
+
+                # Logger should have been called for error
+                # (either in exception handler or for warnings)
+
+        # Restore permissions
+        temp_report_dir.chmod(0o755)
+
+    def test_no_exception_raised_on_write_failure(
+        self,
+        controller: DisplayController,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test no exception raised on write failure."""
+        with patch.dict(os.environ, {"CLAUDE_MONITOR_REPORT_DIR": "/nonexistent/path"}):
+            # Should not raise exception - should fail silently
+            controller._write_state_file(sample_processed_data, sample_args)
+            # If we get here, no exception was raised
+
+    def test_function_returns_early_when_reset_time_none(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test function returns early when reset_time is None."""
+        sample_processed_data["reset_time"] = None
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Should return early without creating file
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert not state_file.exists()
+
+    def test_no_crash_when_timezone_invalid(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test no crash when args.timezone is invalid."""
+        sample_args.timezone = "Invalid/Timezone"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Should not crash - should fall back to default
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            assert state_file.exists()
+
+    def test_graceful_failure_when_processed_data_malformed(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_args: Mock,
+    ) -> None:
+        """Test graceful failure when processed_data is malformed."""
+        # Missing required fields
+        malformed_data = {"tokens_used": 100}
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Should handle gracefully
+            try:
+                controller._write_state_file(malformed_data, sample_args)
+            except Exception:
+                pass  # Expected to fail, but shouldn't crash the app
+
+    # ========================================================================
+    # F. INTEGRATION SCENARIOS TESTS (5 tests)
+    # ========================================================================
+
+    def test_state_file_works_with_pro_plan_limits(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file works with pro plan limits."""
+        sample_args.plan = "pro"
+        sample_processed_data["token_limit"] = 200000
+        sample_processed_data["cost_limit_p90"] = 10.0
+        sample_processed_data["messages_limit_p90"] = 100
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["tokens"]["limit"] == 200000
+
+    def test_state_file_works_with_max5_plan_limits(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file works with max5 plan limits."""
+        sample_args.plan = "max5"
+        sample_processed_data["token_limit"] = 3000000
+        sample_processed_data["cost_limit_p90"] = 50.0
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            assert data["tokens"]["limit"] == 3000000
+
+    def test_state_file_reflects_different_session_states(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file reflects different session states."""
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            # Write state 1
+            sample_processed_data["tokens_used"] = 10000
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data1 = json.load(f)
+
+            # Write state 2
+            sample_processed_data["tokens_used"] = 25000
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            with open(state_file) as f:
+                data2 = json.load(f)
+
+            assert data1["tokens"]["used"] == 10000
+            assert data2["tokens"]["used"] == 25000
+
+    def test_state_file_timezone_matches_args_timezone(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file timezone matches args.timezone."""
+        sample_args.timezone = "Asia/Tokyo"
+        sample_args.time_format = "24h"
+        reset_time = datetime(2026, 1, 10, 15, 0, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data = json.load(f)
+
+            # 15:00 UTC = 00:00 next day JST (UTC+9)
+            # Should be formatted in Tokyo time
+            formatted = data["reset"]["formattedTime"]
+            # Expect hour 0 or 24 depending on formatting
+            assert "00:00" in formatted or "24:00" in formatted
+
+    def test_state_file_time_format_matches_args_time_format(
+        self,
+        controller: DisplayController,
+        temp_report_dir: Path,
+        sample_processed_data: Dict[str, Any],
+        sample_args: Mock,
+    ) -> None:
+        """Test state file time format matches args.time_format."""
+        reset_time = datetime(2026, 1, 10, 14, 30, 0, tzinfo=timezone.utc)
+        sample_processed_data["reset_time"] = reset_time
+
+        # Test 12h format
+        sample_args.timezone = "UTC"
+        sample_args.time_format = "12h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            state_file = temp_report_dir / "current.json"
+            with open(state_file) as f:
+                data12h = json.load(f)
+
+        # Should have AM/PM
+        assert "PM" in data12h["reset"]["formattedTime"]
+
+        # Test 24h format
+        sample_args.time_format = "24h"
+
+        with patch.dict(
+            os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
+        ):
+            controller._write_state_file(sample_processed_data, sample_args)
+
+            with open(state_file) as f:
+                data24h = json.load(f)
+
+        # Should NOT have AM/PM
+        assert "AM" not in data24h["reset"]["formattedTime"]
+        assert "PM" not in data24h["reset"]["formattedTime"]
+        assert "14:30" in data24h["reset"]["formattedTime"]

--- a/src/tests/test_write_state_file.py
+++ b/src/tests/test_write_state_file.py
@@ -531,15 +531,15 @@ class TestWriteStateFile:
     ) -> None:
         """Test lastUpdate is recent (within test execution time)."""
         before_time = (
-            datetime.now()
-        )  # Use local time since write_state_file uses datetime.now()
+            datetime.now(timezone.utc)
+        )  # Use UTC time since write_state_file uses datetime.now(timezone.utc)
 
         with patch.dict(
             os.environ, {"CLAUDE_MONITOR_REPORT_DIR": str(temp_report_dir)}
         ):
             controller._write_state_file(sample_processed_data, sample_args)
 
-        after_time = datetime.now()  # Use local time
+        after_time = datetime.now(timezone.utc)  # Use UTC time
 
         state_file = temp_report_dir / "current.json"
         with open(state_file) as f:


### PR DESCRIPTION
## Summary
Adds `--write-state` flag to enable writing current monitoring state to `~/.claude-monitor/reports/current.json` for consumption by external applications (VS Code extensions, status bar widgets, dashboards).

## Motivation
External tools (IDE extensions, system widgets) need access to real-time Claude usage statistics without parsing terminal output. This feature provides a clean JSON API for integration.

## Changes
- Added `write_state` boolean field to Settings with CLI flag support
- Implemented `_write_state_file()` method in DisplayController
- Added state file writing logic to data display flow
- Created comprehensive STATE_FILE.md documentation with TypeScript/Python types
- Updated README.md with feature information and usage examples
- Added 80+ test cases achieving 72%+ overall coverage

## Files Modified
- `src/claude_monitor/cli/bootstrap.py` - Environment variable setup
- `src/claude_monitor/cli/main.py` - Flag passing to DisplayController
- `src/claude_monitor/core/settings.py` - Settings field definition
- `src/claude_monitor/ui/display_controller.py` - Core implementation
- `STATE_FILE.md` - Comprehensive integration documentation (NEW)
- `README.md` - Feature documentation and examples
- `src/tests/test_write_state_file.py` - Core tests (NEW, 55 tests)
- `src/tests/test_display_controller.py` - Integration tests (14 new tests)
- `src/tests/test_settings.py` - Settings tests (14 new tests)

## Type of Change
- [x] New feature (non-breaking)
- [x] Documentation update
- [x] Tests added

## Testing
- [x] 80+ unit and integration tests added
- [x] 72% overall coverage (exceeds 70% minimum)
- [x] All 596 tests pass
- [x] Manual testing on macOS completed
- [x] Tested with all plan types (pro, max5, max20, custom)
- [x] Tested with multiple timezones and time formats

## Documentation
- [x] STATE_FILE.md created with comprehensive examples
- [x] TypeScript and Python type definitions provided
- [x] README.md updated with usage examples
- [x] Code docstrings complete
- [x] Integration examples for VS Code, Python, Node.js

## Checklist
- [x] Code follows PEP 8 / project style guidelines
- [x] All tests pass locally (pytest)
- [x] Linting passes (ruff check)
- [x] Formatting passes (ruff format)
- [x] Pre-commit hooks pass
- [x] Documentation is complete and accurate
- [x] Commit messages follow convention (feat/fix/docs/test)
- [x] No breaking changes
- [x] Feature is opt-in (default: disabled)

## Example Output
\`\`\`json
{
  "messages": {"used": 140, "limit": 250, "percent": 56.0},
  "tokens": {"used": 17582, "limit": 38705, "percent": 45.43},
  "cost": {"used": 5.13, "limit": 50.0, "percent": 10.25},
  "reset": {
    "timestamp": "2026-01-10T18:00:00+00:00",
    "secondsRemaining": 7920,
    "formattedTime": "6:00 PM"
  },
  "burnRate": {"tokens": 32859.04, "messages": 0},
  "lastUpdate": "2026-01-10T15:48:00.123456"
}
\`\`\`

## Breaking Changes
None - feature is completely opt-in via `--write-state` flag.

## Use Cases
- VS Code extensions showing usage in status bar
- System status bar widgets (macOS, Linux, Windows)
- Custom dashboards and monitoring tools
- Scripts monitoring usage patterns
- Alerts based on usage thresholds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a --write-state CLI flag to optionally export current monitoring state to a JSON file for external tool integration
  * State file includes tokens, cost, messages, reset info, burn rate, and timestamps

* **Documentation**
  * Added comprehensive state file docs with usage examples and README integration guidance
  * Documented report directory configuration and environment variable for report location

* **Tests**
  * Extensive integration and unit tests covering state writing, format, edge cases, permissions, and timezones
<!-- end of auto-generated comment: release notes by coderabbit.ai -->