### PR TITLE
fix: Preserve saved theme preference across sessions

### DIFF
--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -310,9 +310,7 @@ class Settings(BaseSettings):
         if settings.debug:
             settings.log_level = "DEBUG"
 
-        if settings.theme == "auto" or (
-            "theme" not in cli_provided_fields and not clear_config
-        ):
+        if settings.theme == "auto":
             from claude_monitor.terminal.themes import (
                 BackgroundDetector,
                 BackgroundType,


### PR DESCRIPTION
## Summary
- Fixed a bug where saved theme preferences were not properly preserved across sessions
- Resolved an issue where the theme would fallback to auto-detection mode when the `--theme` option was not explicitly provided in the CLI, ignoring the saved preference in `last_used.json`

## Changes
**Modified**: `src/claude_monitor/core/settings.py`
- Simplified the theme auto-detection condition
- Before: `theme == "auto"` OR (theme not provided in CLI AND not clearing config) → auto-detect
- After: Only auto-detect when `theme == "auto"`
- This ensures saved theme preferences (light/dark/classic) persist across sessions

## Problem Context
When a user runs `claude-monitor --theme dark`, the preference is saved to `last_used.json`. On the next run with just `claude-monitor` (without theme option), the saved `dark` theme should be used. However, the previous logic would switch to auto-detection mode simply because the theme was not provided in the CLI arguments.

## Test Plan
- [x] Run `claude-monitor --theme dark` to save dark theme
- [x] Run `claude-monitor` (without options) to verify dark theme persists
- [x] Run `claude-monitor --theme auto` to verify auto-detection still works
- [x] Verify theme preference is saved in `~/.claude-monitor/last_used.json`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactoring**
  * Simplified automatic theme detection logic. Theme will now only automatically detect when explicitly set to "auto" mode, providing more predictable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->