### PR TITLE
fix (timezone/windows):  Implemented support for the `tzlocal`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,8 @@ dependencies = [
   "pytz>=2023.3",
   "rich>=13.7.0",
   "tomli>=1.2.0; python_version < '3.11'",
-  "tzdata; sys_platform == 'win32'"
+  "tzdata; sys_platform == 'win32'",
+  "tzlocal>=5.0"
 ]
 
 [project.optional-dependencies]

--- a/src/claude_monitor/utils/time_utils.py
+++ b/src/claude_monitor/utils/time_utils.py
@@ -123,6 +123,18 @@ except ImportError:
         return None
 
 
+try:
+    from tzlocal import get_localzone_name
+
+    HAS_TZLOCAL = True
+except ImportError:
+    HAS_TZLOCAL = False
+
+    def get_localzone_name():
+        """Stub function when tzlocal is not available."""
+        return None
+
+
 logger: logging.Logger = logging.getLogger(__name__)
 
 
@@ -331,6 +343,14 @@ class SystemTimeDetector:
                 pass
 
         elif system == "Windows":
+            # Try tzlocal first for proper IANA timezone name
+            if HAS_TZLOCAL:
+                with contextlib.suppress(Exception):
+                    tz_name = get_localzone_name()
+                    if tz_name:
+                        return tz_name
+
+            # Fallback to tzutil if tzlocal is not available
             with contextlib.suppress(Exception):
                 tzutil_result: subprocess.CompletedProcess[str] = subprocess.run(
                     ["tzutil", "/g"], capture_output=True, text=True, check=True

--- a/src/tests/test_time_utils.py
+++ b/src/tests/test_time_utils.py
@@ -360,16 +360,33 @@ class TestSystemTimeDetector:
         assert result == "Europe/London"
 
     @patch("platform.system")
+    @patch("claude_monitor.utils.time_utils.HAS_TZLOCAL", True)
+    @patch("claude_monitor.utils.time_utils.get_localzone_name")
+    def test_get_timezone_windows(
+        self, mock_get_localzone_name: Mock, mock_system: Mock
+    ) -> None:
+        """Test Windows timezone detection with tzlocal."""
+        mock_system.return_value = "Windows"
+        mock_get_localzone_name.return_value = "America/New_York"
+
+        # Should return the IANA timezone name from tzlocal
+        result = SystemTimeDetector.get_timezone()
+        assert result == "America/New_York"
+
+    @patch("platform.system")
+    @patch("claude_monitor.utils.time_utils.HAS_TZLOCAL", False)
     @patch("subprocess.run")
-    def test_get_timezone_windows(self, mock_run: Mock, mock_system: Mock) -> None:
-        """Test Windows timezone detection."""
+    def test_get_timezone_windows_fallback(
+        self, mock_run: Mock, mock_system: Mock
+    ) -> None:
+        """Test Windows timezone detection fallback to tzutil when tzlocal is not available."""
         mock_system.return_value = "Windows"
 
         mock_result = Mock()
         mock_result.stdout = "Eastern Standard Time"
         mock_run.return_value = mock_result
 
-        # Should return the Windows timezone name
+        # Should fallback to Windows timezone name from tzutil
         result = SystemTimeDetector.get_timezone()
         assert result == "Eastern Standard Time"
 

--- a/src/tests/test_time_utils.py
+++ b/src/tests/test_time_utils.py
@@ -359,11 +359,12 @@ class TestSystemTimeDetector:
         result = SystemTimeDetector.get_timezone()
         assert result == "Europe/London"
 
-    @patch("platform.system")
-    @patch("claude_monitor.utils.time_utils.HAS_TZLOCAL", True)
-    @patch("claude_monitor.utils.time_utils.get_localzone_name")
+    `@patch`("os.environ.get", return_value=None)
+    `@patch`("platform.system")
+    `@patch`("claude_monitor.utils.time_utils.HAS_TZLOCAL", True)
+    `@patch`("claude_monitor.utils.time_utils.get_localzone_name")
     def test_get_timezone_windows(
-        self, mock_get_localzone_name: Mock, mock_system: Mock
+        self, mock_get_localzone_name: Mock, mock_system: Mock, mock_env: Mock
     ) -> None:
         """Test Windows timezone detection with tzlocal."""
         mock_system.return_value = "Windows"


### PR DESCRIPTION
# Windows Timezone Detection Fix - Implementation Summary

## Problem
The Windows timezone detection in `SystemTimeDetector.get_timezone()` is using `tzutil` which returns Windows-specific timezone IDs (e.g., "Eastern Standard Time", "Pacific Standard Time") instead of IANA timezone names (e.g., "America/New_York", "America/Los_Angeles"). This caused failures for some locales and inconsistent behavior across platforms.

## Solution
Implemented support for the `tzlocal` library (version 5.0+) which properly converts Windows timezone IDs to IANA timezone names, with silent fallback to the original `tzutil` approach if `tzlocal` is not available.

## Changes Made

### 1. Added tzlocal Import (src/claude_monitor/utils/time_utils.py)
```python
try:
    from tzlocal import get_localzone_name

    HAS_TZLOCAL = True
except ImportError:
    HAS_TZLOCAL = False

    def get_localzone_name():
        """Stub function when tzlocal is not available."""
        return None
```

### 2. Updated Windows Timezone Detection (src/claude_monitor/utils/time_utils.py)
```python
elif system == "Windows":
    # Try tzlocal first for proper IANA timezone name
    if HAS_TZLOCAL:
        with contextlib.suppress(Exception):
            tz_name = get_localzone_name()
            if tz_name:
                return tz_name

    # Fallback to tzutil if tzlocal is not available
    with contextlib.suppress(Exception):
        tzutil_result: subprocess.CompletedProcess[str] = subprocess.run(
            ["tzutil", "/g"], capture_output=True, text=True, check=True
        )
        return tzutil_result.stdout.strip()
```

### 3. Added tzlocal Dependency (pyproject.toml)
```toml
dependencies = [
  # ... other dependencies ...
  "tzlocal>=5.0"
]
```

### 4. Updated Tests (src/tests/test_time_utils.py)
Added two tests to cover both the tzlocal and fallback scenarios:
- `test_get_timezone_windows`: Tests tzlocal-based IANA timezone detection
- `test_get_timezone_windows_fallback`: Tests fallback to tzutil when tzlocal is unavailable
- 
Resolves #188 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows timezone detection to prefer IANA names when available and fall back more reliably for unknown cases.

* **Tests**
  * Added tests covering Windows primary and fallback timezone detection, unknown-system fallback, and time format retrieval.

* **Chores**
  * Added optional tzlocal dependency to support improved Windows timezone handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->