### PR TITLE
Fix: Apple Terminal contrast by detecting macOS dark mode

### DIFF
--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -358,9 +358,18 @@ class BackgroundDetector:
                 text=True,
                 timeout=2,
             )
-            if result.returncode == 0 and "dark" in result.stdout.strip().lower():
-                return BackgroundType.DARK
-            return BackgroundType.LIGHT
+            stdout = (result.stdout or "").strip().lower()
+            stderr = (result.stderr or "").strip().lower()
+
+            if result.returncode == 0:
+                return BackgroundType.DARK if "dark" in stdout else BackgroundType.LIGHT
+
+            # Light mode: the AppleInterfaceStyle key is absent
+            if "does not exist" in stderr and "appleinterfacestyle" in stderr:
+                return BackgroundType.LIGHT
+
+            # Any other command failure should prefer the contrast-safe fallback
+            return BackgroundType.DARK
         except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
             # If detection fails, fall back to DARK as most modern macOS
             # users have dark mode enabled

--- a/src/claude_monitor/terminal/themes.py
+++ b/src/claude_monitor/terminal/themes.py
@@ -323,7 +323,9 @@ class BackgroundDetector:
         if "TERM_PROGRAM" in os.environ:
             term_program: str = os.environ["TERM_PROGRAM"]
             if term_program == "Apple_Terminal":
-                return BackgroundType.LIGHT
+                # Apple Terminal follows macOS system appearance since Mojave.
+                # Detect actual system dark/light mode instead of assuming light.
+                return BackgroundDetector._check_macos_appearance()
             if term_program == "iTerm.app":
                 return BackgroundType.DARK
 
@@ -335,6 +337,34 @@ class BackgroundDetector:
             return BackgroundType.DARK
 
         return BackgroundType.UNKNOWN
+
+    @staticmethod
+    def _check_macos_appearance() -> BackgroundType:
+        """Detect macOS system appearance (dark mode vs light mode).
+
+        Uses 'defaults read -g AppleInterfaceStyle' which returns 'Dark'
+        when dark mode is active. The command fails (non-zero exit) when
+        light mode is active, as the key is absent.
+
+        Returns:
+            DARK if macOS dark mode is enabled, LIGHT otherwise.
+        """
+        import subprocess
+
+        try:
+            result = subprocess.run(
+                ["defaults", "read", "-g", "AppleInterfaceStyle"],
+                capture_output=True,
+                text=True,
+                timeout=2,
+            )
+            if result.returncode == 0 and "dark" in result.stdout.strip().lower():
+                return BackgroundType.DARK
+            return BackgroundType.LIGHT
+        except (subprocess.TimeoutExpired, FileNotFoundError, OSError):
+            # If detection fails, fall back to DARK as most modern macOS
+            # users have dark mode enabled
+            return BackgroundType.DARK
 
     @staticmethod
     def _query_background_color() -> BackgroundType:

--- a/src/tests/test_background_detection.py
+++ b/src/tests/test_background_detection.py
@@ -21,9 +21,28 @@ class TestCheckMacosAppearance:
     @patch("subprocess.run")
     def test_light_mode_detected(self, mock_run: MagicMock) -> None:
         """Light mode (key absent, non-zero exit) returns LIGHT background type."""
-        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr=(
+                "2026-04-12 16:00:00.000 defaults[1234:5678]\n"
+                "The domain/default pair of (kCFPreferencesAnyApplication, "
+                "AppleInterfaceStyle) does not exist"
+            ),
+        )
         result = BackgroundDetector._check_macos_appearance()
         assert result == BackgroundType.LIGHT
+
+    @patch("subprocess.run")
+    def test_unexpected_nonzero_exit_falls_back_to_dark(self, mock_run: MagicMock) -> None:
+        """Non-zero exit with unexpected stderr falls back to DARK for contrast safety."""
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="some unexpected error",
+        )
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.DARK
 
     @patch("subprocess.run")
     def test_command_timeout_falls_back_to_dark(self, mock_run: MagicMock) -> None:
@@ -50,7 +69,7 @@ class TestCheckMacosAppearance:
 class TestAppleTerminalDetection:
     """Test that Apple Terminal uses macOS appearance detection."""
 
-    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=False)
+    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=True)
     @patch.object(BackgroundDetector, "_check_macos_appearance")
     def test_apple_terminal_delegates_to_macos_appearance(
         self, mock_appearance: MagicMock
@@ -61,7 +80,7 @@ class TestAppleTerminalDetection:
         assert result == BackgroundType.DARK
         mock_appearance.assert_called_once()
 
-    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=False)
+    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=True)
     @patch.object(BackgroundDetector, "_check_macos_appearance")
     def test_apple_terminal_light_mode(
         self, mock_appearance: MagicMock

--- a/src/tests/test_background_detection.py
+++ b/src/tests/test_background_detection.py
@@ -1,0 +1,73 @@
+"""Tests for macOS appearance detection in BackgroundDetector."""
+
+import subprocess
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from claude_monitor.terminal.themes import BackgroundDetector, BackgroundType
+
+
+class TestCheckMacosAppearance:
+    """Test suite for BackgroundDetector._check_macos_appearance."""
+
+    @patch("subprocess.run")
+    def test_dark_mode_detected(self, mock_run: MagicMock) -> None:
+        """Dark mode returns DARK background type."""
+        mock_run.return_value = MagicMock(returncode=0, stdout="Dark\n")
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.DARK
+
+    @patch("subprocess.run")
+    def test_light_mode_detected(self, mock_run: MagicMock) -> None:
+        """Light mode (key absent, non-zero exit) returns LIGHT background type."""
+        mock_run.return_value = MagicMock(returncode=1, stdout="")
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.LIGHT
+
+    @patch("subprocess.run")
+    def test_command_timeout_falls_back_to_dark(self, mock_run: MagicMock) -> None:
+        """Timeout during detection falls back to DARK."""
+        mock_run.side_effect = subprocess.TimeoutExpired(cmd="defaults", timeout=2)
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.DARK
+
+    @patch("subprocess.run")
+    def test_command_not_found_falls_back_to_dark(self, mock_run: MagicMock) -> None:
+        """Missing 'defaults' command (non-macOS) falls back to DARK."""
+        mock_run.side_effect = FileNotFoundError()
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.DARK
+
+    @patch("subprocess.run")
+    def test_os_error_falls_back_to_dark(self, mock_run: MagicMock) -> None:
+        """OS error falls back to DARK."""
+        mock_run.side_effect = OSError("Permission denied")
+        result = BackgroundDetector._check_macos_appearance()
+        assert result == BackgroundType.DARK
+
+
+class TestAppleTerminalDetection:
+    """Test that Apple Terminal uses macOS appearance detection."""
+
+    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=False)
+    @patch.object(BackgroundDetector, "_check_macos_appearance")
+    def test_apple_terminal_delegates_to_macos_appearance(
+        self, mock_appearance: MagicMock
+    ) -> None:
+        """Apple Terminal should check macOS appearance instead of assuming light."""
+        mock_appearance.return_value = BackgroundType.DARK
+        result = BackgroundDetector._check_environment_hints()
+        assert result == BackgroundType.DARK
+        mock_appearance.assert_called_once()
+
+    @patch.dict("os.environ", {"TERM_PROGRAM": "Apple_Terminal"}, clear=False)
+    @patch.object(BackgroundDetector, "_check_macos_appearance")
+    def test_apple_terminal_light_mode(
+        self, mock_appearance: MagicMock
+    ) -> None:
+        """Apple Terminal in light mode returns LIGHT."""
+        mock_appearance.return_value = BackgroundType.LIGHT
+        result = BackgroundDetector._check_environment_hints()
+        assert result == BackgroundType.LIGHT
+        mock_appearance.assert_called_once()


### PR DESCRIPTION
## Problem

Apple Terminal (`TERM_PROGRAM=Apple_Terminal`) is hard-coded to return `BackgroundType.LIGHT` in `BackgroundDetector._check_environment_hints()`. However, since macOS Mojave (2018), Apple Terminal follows the system appearance — and most modern macOS users run **dark mode**.

This causes light-theme colors (dark foreground text) to be applied on a dark terminal background, resulting in **near-zero contrast** where labels, values, and progress bars are barely readable.

**Affected:** Any macOS user running dark mode with the native Terminal.app.
**Not affected:** iTerm2 users (correctly detected as DARK).

### Screenshots

#### macOS Terminal.app (before fix — barely readable)
<img width="1440" height="900" alt="Native_Terminal_App" src="https://github.com/user-attachments/assets/3c55e09e-3845-4d71-bf1b-64fd6dd4c350" />

#### iTerm2 (works correctly)
<img width="1440" height="900" alt="iTerm" src="https://github.com/user-attachments/assets/81978351-be17-49d9-a1e3-922301bde590" />

## Fix

Instead of assuming `LIGHT` for Apple Terminal, the detector now calls a new `_check_macos_appearance()` method that queries the actual macOS system appearance:

```
defaults read -g AppleInterfaceStyle
```

- Returns `"Dark"` → `BackgroundType.DARK`
- Command fails (key absent in light mode) → `BackgroundType.LIGHT`
- Any error (timeout, non-macOS, permissions) → falls back to `BackgroundType.DARK`

The fallback to DARK matches the reality that most macOS users today have dark mode enabled.

## Changes

- `src/claude_monitor/terminal/themes.py`: Added `_check_macos_appearance()` static method to `BackgroundDetector`. Updated `_check_environment_hints()` to call it for Apple Terminal instead of returning hard-coded `LIGHT`.
- `src/tests/test_background_detection.py`: 7 new tests covering dark mode detection, light mode detection, timeout/error fallbacks, and Apple Terminal delegation.

## Testing

- All 524 existing tests pass (0 failures)
- 7 new tests added and passing
- Verified live on macOS with dark mode enabled — Apple Terminal now correctly returns `DARK`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Apple Terminal on macOS now respects the system dark/light appearance via a new macOS appearance check, with improved fallbacks and error handling for timeouts, missing utilities, or unexpected responses.

* **Tests**
  * Added unit tests covering macOS appearance detection and Apple Terminal theme detection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->