### PR TITLE
Add: cum command alias (mnemonic for Claude Usage Monitor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### 🆕 New Features
+- **New command alias**: Added `cum` as a sixth invocation alias for the tool — a mnemonic for **C**laude **U**sage **M**onitor. All existing aliases (`claude-monitor`, `claude-code-monitor`, `cmonitor`, `ccmonitor`, `ccm`) continue to work unchanged.
+
 ## [3.1.0] - 2025-07-23
 
 ### 🆕 New Features

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,7 +37,7 @@ Current implementation status and planned features for Claude Code Usage Monitor
 
 #### 📦 **Package Distribution**
 - **PyPI-ready** with modern setuptools configuration
-- **Entry points**: `claude-monitor`, `cmonitor`, and `ccm` commands
+- **Entry points**: `claude-monitor`, `cmonitor`, `ccm`, and `cum` commands
 - **Cross-platform support** (Windows, macOS, Linux)
 - **Professional CI/CD** with automated testing and releases
 
@@ -45,6 +45,7 @@ Current implementation status and planned features for Claude Code Usage Monitor
 - `claude-monitor` - Main command (full name)
 - `cmonitor` - Short alias for convenience
 - `ccm` - Ultra-short alias for power users
+- `cum` - Mnemonic alias (Claude Usage Monitor)
 
 #### 🛠️ **Development Infrastructure**
 - **100+ test cases** with comprehensive coverage (80% requirement)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The fastest and easiest way to install and use the monitor:
 uv tool install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -137,7 +137,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc  # or restart your terminal
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -159,7 +159,7 @@ claude-monitor  # or cmonitor, ccmonitor for short
 pipx install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm for short
+claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm, cum for short
 ```
 
 
@@ -169,7 +169,7 @@ claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm for short
 pip install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -218,6 +218,7 @@ The tool can be invoked using any of these commands:
 - cmonitor (short)
 - ccmonitor (short alternative)
 - ccm (shortest)
+- cum (mnemonic: Claude Usage Monitor)
 
 #### Save Flags Feature
 
@@ -268,6 +269,7 @@ claude-code-monitor  # Full descriptive name
 cmonitor             # Short alias
 ccmonitor            # Short alternative
 ccm                  # Shortest alias
+cum                  # Mnemonic: Claude Usage Monitor
 
 # Exit the monitor
 # Press Ctrl+C to gracefully exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ claude-code-monitor = "claude_monitor.__main__:main"
 cmonitor = "claude_monitor.__main__:main"
 ccmonitor = "claude_monitor.__main__:main"
 ccm = "claude_monitor.__main__:main"
+cum = "claude_monitor.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
## Summary

The project's full name is **C**laude **U**sage **M**onitor — yet the obvious `cum` mnemonic isn't in the alias list. Fixing that.

This PR adds a sixth invocation alias `cum` alongside the existing five (`claude-monitor`, `claude-code-monitor`, `cmonitor`, `ccmonitor`, `ccm`).

- Wires up `cum` as a new `[project.scripts]` entry in `pyproject.toml`, pointing at the same `claude_monitor.__main__:main` entry as the others.
- Adds `cum` to every doc that enumerates the alias list: `README.md` (the four install-snippet comments, the formal "Command Aliases" bullet list, and the "Alternative commands" code block), `DEVELOPMENT.md` (entry-points line + alias bullet list), and a new `[Unreleased]` `CHANGELOG.md` entry.

Purely additive. No behavior changes, no package name change, no test changes — the package itself is still `claude-monitor` (config dir `~/.claude-monitor/`, env vars `CLAUDE_MONITOR_*`, `--version` banner all unchanged). All existing aliases continue to work.

## Test plan

- [ ] `uv tool install --reinstall .` then `cum --help` prints the same help as `claude-monitor --help`
- [ ] `cum --version` prints `claude-monitor <version>`
- [ ] Existing aliases still work: `claude-monitor --version && cmonitor --version && ccm --version`
- [ ] `pytest src/tests/test_cli_main.py src/tests/test_version.py src/tests/test_settings.py` still passes (no test changes)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line alias `cum` as an additional way to invoke the tool.

* **Documentation**
  * Updated CHANGELOG documenting the new alias.
  * Updated DEVELOPMENT.md with the new CLI entry point.
  * Updated README with the new alias and usage examples across all installation methods (uv, pip, pipx, conda/mamba).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->