### PR TITLE
Add cum alias

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [Unreleased]
+
+### 🆕 New Features
+- **New command alias**: Added `cum` as a sixth invocation alias for the tool — a mnemonic for **C**laude **U**sage **M**onitor. All existing aliases (`claude-monitor`, `claude-code-monitor`, `cmonitor`, `ccmonitor`, `ccm`) continue to work unchanged.
+
 ## [3.1.0] - 2025-07-23
 
 ### 🆕 New Features

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -37,7 +37,7 @@ Current implementation status and planned features for Claude Code Usage Monitor
 
 #### 📦 **Package Distribution**
 - **PyPI-ready** with modern setuptools configuration
-- **Entry points**: `claude-monitor`, `cmonitor`, and `ccm` commands
+- **Entry points**: `claude-monitor`, `cmonitor`, `ccm`, and `cum` commands
 - **Cross-platform support** (Windows, macOS, Linux)
 - **Professional CI/CD** with automated testing and releases
 
@@ -45,6 +45,7 @@ Current implementation status and planned features for Claude Code Usage Monitor
 - `claude-monitor` - Main command (full name)
 - `cmonitor` - Short alias for convenience
 - `ccm` - Ultra-short alias for power users
+- `cum` - Mnemonic alias (Claude Usage Monitor)
 
 #### 🛠️ **Development Infrastructure**
 - **100+ test cases** with comprehensive coverage (80% requirement)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The fastest and easiest way to install and use the monitor:
 uv tool install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -137,7 +137,7 @@ echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
 source ~/.bashrc  # or restart your terminal
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -159,7 +159,7 @@ claude-monitor  # or cmonitor, ccmonitor for short
 pipx install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm for short
+claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm, cum for short
 ```
 
 
@@ -169,7 +169,7 @@ claude-monitor  # or claude-code-monitor, cmonitor, ccmonitor, ccm for short
 pip install claude-monitor
 
 # Run from anywhere
-claude-monitor  # or cmonitor, ccmonitor for short
+claude-monitor  # or cmonitor, ccmonitor, cum for short
 ```
 
 
@@ -218,6 +218,7 @@ The tool can be invoked using any of these commands:
 - cmonitor (short)
 - ccmonitor (short alternative)
 - ccm (shortest)
+- cum (mnemonic: Claude Usage Monitor)
 
 #### Save Flags Feature
 
@@ -268,6 +269,7 @@ claude-code-monitor  # Full descriptive name
 cmonitor             # Short alias
 ccmonitor            # Short alternative
 ccm                  # Shortest alias
+cum                  # Mnemonic: Claude Usage Monitor
 
 # Exit the monitor
 # Press Ctrl+C to gracefully exit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -88,6 +88,7 @@ claude-code-monitor = "claude_monitor.__main__:main"
 cmonitor = "claude_monitor.__main__:main"
 ccmonitor = "claude_monitor.__main__:main"
 ccm = "claude_monitor.__main__:main"
+cum = "claude_monitor.__main__:main"
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
The project is **C**laude **U**sage **M**onitor. The alias was missing.

Adds `cum` as a sixth entry in `[project.scripts]`, pointing at the same `claude_monitor.__main__:main` as the other five. Updates the docs that enumerate the alias list (README, CHANGELOG, DEVELOPMENT). Nothing else changes — package name, config dir, env vars, version banner, and tests are all untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new command-line alias option. All existing aliases remain fully functional with no behavior changes.

* **Documentation**
  * Updated documentation, configuration files, and changelog to reflect the new alias availability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->