### PR TITLE
Add pace indicator (speed up / slow down)

### DIFF
--- a/src/claude_monitor/ui/session_display.py
+++ b/src/claude_monitor/ui/session_display.py
@@ -94,6 +94,45 @@ class SessionDisplayComponent:
 
         return f"{color} [{filled_bar}]"
 
+    def _render_pace(
+        self,
+        burn_rate: float,
+        tokens_used: int,
+        token_limit: int,
+        time_remaining_minutes: float,
+    ) -> str:
+        """Render pace advice comparing current burn rate to the sustainable rate.
+
+        The sustainable rate is the steady tokens/min that would spend exactly
+        the remaining tokens by the time the session resets. Burning faster than
+        that means tokens run out early (slow down); slower means there's headroom.
+        """
+        label = "🏃 [value]Pace:[/]                   "
+
+        if token_limit <= 0 or time_remaining_minutes <= 0:
+            return f"{label}[dim]—[/]"
+
+        tokens_left = max(0, token_limit - tokens_used)
+        if tokens_left <= 0:
+            return f"{label}[error]🔴 Limit reached[/]"
+
+        sustainable_rate = tokens_left / time_remaining_minutes
+        detail = f"[dim]{burn_rate:.0f}/min vs {sustainable_rate:.0f}/min sustainable[/]"
+
+        # Within 10% either way counts as on pace.
+        if abs(burn_rate - sustainable_rate) <= 0.1 * sustainable_rate:
+            return f"{label}[success]✅ On pace[/] {detail}"
+
+        if burn_rate > sustainable_rate:
+            minutes_until_empty = tokens_left / burn_rate
+            minutes_early = max(0, time_remaining_minutes - minutes_until_empty)
+            return (
+                f"{label}[warning]🐢 Slow down[/] {detail} "
+                f"[dim](tokens run out ~{minutes_early:.0f}m before reset)[/]"
+            )
+
+        return f"{label}[info]🚀 Room to spare[/] {detail} [dim](you could go faster)[/]"
+
     def format_active_session_screen_v2(self, data: SessionDisplayData) -> list[str]:
         """Format complete active session screen using data class.
 
@@ -254,6 +293,11 @@ class SessionDisplayComponent:
             velocity_emoji = VelocityIndicator.get_velocity_emoji(burn_rate)
             screen_buffer.append(
                 f"🔥 [value]Burn Rate:[/]              [warning]{burn_rate:.1f}[/] [dim]tokens/min[/] {velocity_emoji}"
+            )
+            screen_buffer.append(
+                self._render_pace(
+                    burn_rate, tokens_used, token_limit, time_remaining
+                )
             )
 
             cost_per_min = (

--- a/src/tests/test_session_display.py
+++ b/src/tests/test_session_display.py
@@ -1,0 +1,48 @@
+"""Tests for SessionDisplayComponent pace advice."""
+
+from claude_monitor.ui.session_display import SessionDisplayComponent
+
+
+def _pace(burn_rate, tokens_used, token_limit, time_remaining):
+    """Render the pace line for the given inputs."""
+    return SessionDisplayComponent()._render_pace(
+        burn_rate, tokens_used, token_limit, time_remaining
+    )
+
+
+def test_slow_down_when_burning_faster_than_sustainable():
+    """Burning faster than sustainable should advise slowing down."""
+    # 5000 tokens left over 50 min -> sustainable 100/min; burning 200/min.
+    result = _pace(200, 5000, 10000, 50)
+    assert "Slow down" in result
+    assert "before reset" in result
+
+
+def test_room_to_spare_when_burning_slower():
+    """Burning slower than sustainable should report spare headroom."""
+    # sustainable 100/min, burning 40/min.
+    result = _pace(40, 5000, 10000, 50)
+    assert "Room to spare" in result
+
+
+def test_on_pace_within_tolerance():
+    """A rate within 10% of sustainable should read as on pace."""
+    # sustainable 100/min, burning 105/min (within 10%).
+    result = _pace(105, 5000, 10000, 50)
+    assert "On pace" in result
+
+
+def test_limit_reached_when_no_tokens_left():
+    """No tokens left should report the limit has been reached."""
+    result = _pace(100, 10000, 10000, 50)
+    assert "Limit reached" in result
+
+
+def test_no_advice_without_time_window():
+    """No remaining time means no pace advice can be given."""
+    assert "—" in _pace(100, 5000, 10000, 0)
+
+
+def test_no_advice_without_known_limit():
+    """An unknown token limit means no pace advice can be given."""
+    assert "—" in _pace(100, 5000, 0, 50)


### PR DESCRIPTION
## Summary
Adds a **Pace** line to the active-session view, right under Burn Rate. It compares your current burn rate against the *sustainable* rate — the steady tokens/min that would use up your remaining tokens exactly when the session resets — and tells you whether to ease off or that you have headroom.

It looks like:

```
🔥 Burn Rate:              1024.8 tokens/min ⚡
🏃 Pace:                   ✅ On pace  1025/min vs 951/min sustainable
💲 Cost Rate:              $0.2554 $/min
```

Verdicts:
- 🐢 **Slow down** — burning faster than sustainable; also shows roughly how many minutes early tokens would run out.
- 🚀 **Room to spare** — burning slower; you could go faster.
- ✅ **On pace** — within 10% of sustainable.
- Graceful fallbacks for no time window, unknown limit, or limit already reached.

All inputs (`burn_rate`, `tokens_used`, `token_limit`, time to reset) are already computed at the render site, so there's no new data plumbing. Added to the custom/pro/max5/max20 layout.

## Test plan
- [x] New unit tests in `src/tests/test_session_display.py` cover slow-down, room-to-spare, on-pace, limit-reached, and the no-data fallbacks (6 tests, all passing).
- [x] Verified live rendering against real usage data.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a pace-advice line to the active session display that indicates whether the current token burn is sustainable until reset, with clear visual status (error/warning/success/info).

* **Tests**
  * Added tests covering pace-advice rendering across fast/slow/on-pace scenarios, limit-reached, and cases with no available time or unknown limit.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Maciek-roboblog/Claude-Code-Usage-Monitor/pull/216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->