### PR TITLE
docs: add native macOS companion app to Companion Apps section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1282,6 +1282,16 @@ A special thanks to our supporters who help keep this project going:
 **Ed** - *Buy Me Coffee Supporter*
 > "I appreciate sharing your work with the world. It helps keep me on track with my day. Quality readme, and really good stuff all around!"
 
+## 🛠️ Companion Apps
+
+Community-built tools that extend claude-code-usage-monitor via the v4 state protocol:
+
+| App | Platform | Description |
+|-----|----------|-------------|
+| [Claude Token Monitor](https://github.com/HAOGRE/ClaudeTokenMonitorBar-macOS) | macOS menu bar | Native Swift/SwiftUI app — live token rates, cost tracking, and official 5-hour rate limit display via v4 state protocol. Zero dependencies, Universal binary. |
+
+> Built a companion tool? Open a PR to add it here.
+
 ## Star History
 
 [![Star History Chart](https://api.star-history.com/svg?repos=Maciek-roboblog/Claude-Code-Usage-Monitor&type=Date)](https://www.star-history.com/#Maciek-roboblog/Claude-Code-Usage-Monitor&Date)


### PR DESCRIPTION
## Preview
### Status Bar

|                     Active (Token Rates)                     |                   Idle (Accumulated Cost)                    |
| :----------------------------------------------------------: | :----------------------------------------------------------: |
| <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/statusbar-rate.png" width="400" /> | <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/statusbar-cost.png" width="400" /> |

### Dark Mode

|                             Day                              |                             Week                             |                            Month                             |
| :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
| <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/dark-day.png" width="220" /> | <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/dark-week.png" width="220" /> | <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/dark-month.png" width="220" /> |

### Light Mode

|                             Day                              |                             Week                             |                            Month                             |
| :----------------------------------------------------------: | :----------------------------------------------------------: | :----------------------------------------------------------: |
| <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/light-day.png" width="220" /> | <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/light-week.png" width="220" /> | <img src="https://raw.githubusercontent.com/HAOGRE/ClaudeTokenMonitorBar-macOS/main/assets/screenshots/light-month.png" width="220" /> |

---

## Summary

Following up on the feedback from #215 — as suggested, I've built a **separate companion repository** that consumes the v4 state protocol instead of being merged into the core package.

This PR adds a small **Companion Apps** section to the README listing the macOS menu bar app.

---

## What was built

**[Claude Token Monitor for macOS](https://github.com/HAOGRE/ClaudeTokenMonitorBar-macOS)**

A native Swift/SwiftUI menu bar app that:
- Reads `~/.claude/projects/*.jsonl` directly for token stats and cost tracking
- **Consumes the monitor's generated v4 state protocol at runtime** to display the official 5-hour rate limit window with a progress bar and reset time
- Zero external dependencies, Universal binary (Intel + Apple Silicon), macOS 14.0+
- The v4 rate limit section appears automatically when this monitor is running; if not, the app works standalone

This strictly follows the companion-app architecture you outlined: the Python project owns the data/protocol layer, the macOS app is a pure consumer.

---

## Change

Single addition to README.md: a **🛠️ Companion Apps** section before Star History, with one table row linking to the macOS app.

Happy to adjust the wording, placement, or table format to fit your style.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new “Companion Apps” section to the README acknowledgments area.
  * Highlighted a community-built companion tool with a brief description and platform details.
  * Included a note inviting additional companion apps to be added in future updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
