### PR TITLE
feat: add --from/--to date-range filtering for daily and monthly views

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,8 @@ claude-monitor --help
 | --refresh-per-second | float | 0.75 | Display refresh rate in Hz (0.1-20.0) |
 | --reset-hour | int | None | Daily reset hour (0-23) |
 | --date-format | string | None | Date format for daily/monthly table periods |
+| --from | string | None | Start of date range, inclusive. daily: `YYYY-MM-DD`, monthly: `YYYY-MM`. May be used alone |
+| --to | string | None | End of date range, inclusive. daily: `YYYY-MM-DD`, monthly: `YYYY-MM`. May be used alone |
 | --abbreviate-tokens | flag | False | Abbreviate token counts in table views |
 | --sparklines | flag | False | Show opt-in sparklines in table views |
 | --filter-models | string | all | Use all models, or anthropic to exclude routed non-Claude models |
@@ -216,6 +218,27 @@ claude-monitor --help
 | --debug | flag | False | Enable debug logging |
 | --version, -v | flag | False | Show version information |
 | --clear | flag | False | Clear saved configuration |
+
+#### Filtering daily/monthly views by date range
+
+`--from` / `--to` restrict the `--view daily` and `--view monthly` tables to an
+inclusive date range. The accepted format depends on the view: `daily` expects
+`YYYY-MM-DD`, `monthly` expects `YYYY-MM`. Either bound may be given on its own.
+
+```bash
+claude-monitor --view daily   --from 2026-06-01 --to 2026-06-15
+claude-monitor --view monthly --from 2026-01    --to 2026-06
+claude-monitor --view daily   --from 2026-06-10                  # everything since that day
+```
+
+> **Note — local log retention limits how far back you can go.** These views read
+> Claude Code's local session logs in `~/.claude/projects/`. Claude Code keeps
+> those logs for `cleanupPeriodDays` days (**default 30**) and deletes older ones
+> at startup, so a `--from`/`--to` range that reaches past that window simply
+> returns no rows (it is a filter, not an error). For usable long-range monthly
+> views, raise `cleanupPeriodDays` in `~/.claude/settings.json` (e.g. `365`). Do
+> **not** set it to `0` — that disables transcript persistence entirely. See the
+> [Claude Code settings docs](https://code.claude.com/docs/en/settings).
 
 #### Plan Options
 

--- a/src/claude_monitor/cli/main.py
+++ b/src/claude_monitor/cli/main.py
@@ -710,6 +710,8 @@ def _run_table_view(
             timezone=args.timezone,
             reset_hour=getattr(args, "reset_hour", None),
             filter_models=getattr(args, "filter_models", "all"),
+            date_from=getattr(args, "date_from", None),
+            date_to=getattr(args, "date_to", None),
         )
 
         # Create table controller

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -561,7 +561,15 @@ class Settings(BaseSettings):
             last_used = LastUsedParams()
             last_params = last_used.load()
 
-            settings = cls(_cli_parse_args=argv)
+            effective_argv = list(argv) if argv else []
+            cli_has_view = any(
+                arg == "--view" or arg.startswith("--view=") for arg in effective_argv
+            )
+            saved_view = last_params.get("view")
+            if not cli_has_view and saved_view in ("daily", "monthly"):
+                effective_argv = ["--view", saved_view, *effective_argv]
+
+            settings = cls(_cli_parse_args=effective_argv)
 
             cli_provided_fields = set()
             # Map aliases (e.g. --from -> date_from) back to field names so an

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -494,20 +494,29 @@ class Settings(BaseSettings):
 
         date_pattern = "%Y-%m-%d" if self.view == "daily" else "%Y-%m"
         expected = "YYYY-MM-DD" if self.view == "daily" else "YYYY-MM"
+        parsed: Dict[str, datetime] = {}
         for label, value in (("--from", self.date_from), ("--to", self.date_to)):
-            if value is not None:
-                try:
-                    datetime.strptime(value, date_pattern)
-                except ValueError:
-                    raise ValueError(
-                        f"{label} value {value!r} is invalid for --view "
-                        f"{self.view}; expected {expected}"
-                    )
+            if value is None:
+                continue
+            try:
+                dt = datetime.strptime(value, date_pattern)
+            except ValueError:
+                dt = None
+            # strptime accepts non-canonical input like "2026-6-1"; require the
+            # value to round-trip so only zero-padded YYYY-MM-DD / YYYY-MM pass.
+            if dt is None or dt.strftime(date_pattern) != value:
+                raise ValueError(
+                    f"{label} value {value!r} is invalid for --view "
+                    f"{self.view}; expected {expected}"
+                )
+            parsed[label] = dt
 
+        # Compare parsed datetimes, not raw strings: "2026-6" > "2026-10" is a
+        # lexical false positive that the parsed comparison avoids.
         if (
-            self.date_from is not None
-            and self.date_to is not None
-            and self.date_from > self.date_to
+            "--from" in parsed
+            and "--to" in parsed
+            and parsed["--from"] > parsed["--to"]
         ):
             raise ValueError(
                 f"--from ({self.date_from}) is after --to ({self.date_to})"
@@ -555,11 +564,20 @@ class Settings(BaseSettings):
             settings = cls(_cli_parse_args=argv)
 
             cli_provided_fields = set()
+            # Map aliases (e.g. --from -> date_from) back to field names so an
+            # aliased flag is recognized as CLI-provided and not overwritten by
+            # a saved last-used value.
+            alias_to_field = {
+                field.alias: name
+                for name, field in cls.model_fields.items()
+                if field.alias is not None
+            }
             if argv:
                 for _i, arg in enumerate(argv):
                     if arg.startswith("--"):
                         # Handle both "--plan pro" and "--plan=pro" forms.
                         field_name = arg[2:].split("=", 1)[0].replace("-", "_")
+                        field_name = alias_to_field.get(field_name, field_name)
                         if field_name in cls.model_fields:
                             cli_provided_fields.add(field_name)
 

--- a/src/claude_monitor/core/settings.py
+++ b/src/claude_monitor/core/settings.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Literal, Optional, Tuple
 
 import pytz
-from pydantic import Field, field_validator
+from pydantic import Field, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from claude_monitor import __version__
@@ -101,6 +101,7 @@ class Settings(BaseSettings):
         cli_prog_name="claude-monitor",
         cli_kebab_case=True,
         cli_implicit_flags=True,
+        populate_by_name=True,
     )
 
     plan: Literal["pro", "max5", "max20", "team", "custom"] = Field(
@@ -271,6 +272,22 @@ class Settings(BaseSettings):
     date_format: Optional[str] = Field(
         default=None,
         description="Date format for daily/monthly table periods, e.g. %d.%m.%Y",
+    )
+
+    date_from: Optional[str] = Field(
+        default=None,
+        alias="from",
+        description=(
+            "Start of date range, inclusive. daily: YYYY-MM-DD, monthly: YYYY-MM"
+        ),
+    )
+
+    date_to: Optional[str] = Field(
+        default=None,
+        alias="to",
+        description=(
+            "End of date range, inclusive. daily: YYYY-MM-DD, monthly: YYYY-MM"
+        ),
     )
 
     abbreviate_tokens: bool = Field(
@@ -451,6 +468,53 @@ class Settings(BaseSettings):
             raise ValueError(f"Invalid log level: {v}")
         return v_upper
 
+    @model_validator(mode="after")
+    def validate_date_range(self) -> "Settings":
+        """Validate ``--from``/``--to`` against the active view.
+
+        The accepted format depends on ``view``: ``daily`` expects
+        ``YYYY-MM-DD`` and ``monthly`` expects ``YYYY-MM``. Both boundaries are
+        optional (one-sided ranges are allowed), but when both are present the
+        start must not be after the end. The flags only apply to the ``daily``
+        and ``monthly`` table views.
+
+        Returns:
+            The validated settings instance.
+
+        Raises:
+            ValueError: If a date is malformed for the active view, if the
+                flags are used with an unsupported view, or if ``date_from`` is
+                after ``date_to``.
+        """
+        if self.date_from is None and self.date_to is None:
+            return self
+
+        if self.view not in ("daily", "monthly"):
+            raise ValueError("--from/--to only apply to --view daily or --view monthly")
+
+        date_pattern = "%Y-%m-%d" if self.view == "daily" else "%Y-%m"
+        expected = "YYYY-MM-DD" if self.view == "daily" else "YYYY-MM"
+        for label, value in (("--from", self.date_from), ("--to", self.date_to)):
+            if value is not None:
+                try:
+                    datetime.strptime(value, date_pattern)
+                except ValueError:
+                    raise ValueError(
+                        f"{label} value {value!r} is invalid for --view "
+                        f"{self.view}; expected {expected}"
+                    )
+
+        if (
+            self.date_from is not None
+            and self.date_to is not None
+            and self.date_from > self.date_to
+        ):
+            raise ValueError(
+                f"--from ({self.date_from}) is after --to ({self.date_to})"
+            )
+
+        return self
+
     @classmethod
     def settings_customise_sources(
         cls,
@@ -582,6 +646,8 @@ class Settings(BaseSettings):
         args.warehouse_file = self.warehouse_file
         args.warehouse_retention_days = self.warehouse_retention_days
         args.date_format = self.date_format
+        args.date_from = self.date_from
+        args.date_to = self.date_to
         args.abbreviate_tokens = self.abbreviate_tokens
         args.sparklines = self.sparklines
         args.filter_models = self.filter_models

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -342,12 +342,20 @@ class UsageAggregator:
     def _range_bounds(self) -> Tuple[Optional[datetime], Optional[datetime]]:
         """Convert ``date_from``/``date_to`` into timezone-aware boundaries.
 
-        The boundaries are built in the display timezone (``self.timezone``) so a
-        date like ``2026-06-05`` means the user's local June 5th. They are
-        timezone-aware to match ``entry.timestamp`` (made aware in ``aggregate``);
-        comparing aware against naive datetimes would raise. Both bounds are
-        inclusive: the start snaps to the first instant of its day/month and the
-        end to the last microsecond of its day/month.
+        The bounds are built to match the calendar the period **keys** use, so
+        the filter never includes or drops a boundary entry that the keying would
+        bucket into a different period:
+
+        * Default daily and all monthly keys ``strftime`` the raw UTC-aware
+          ``entry.timestamp`` (made aware as UTC in ``aggregate``). The bounds are
+          therefore built on the **UTC** calendar — ``2026-06-05`` means UTC
+          June 5th, the same day the key would assign.
+        * Daily with ``reset_hour`` and an explicit timezone keys against the
+          display timezone shifted by ``reset_hour`` (see ``_day_key``). The
+          bounds follow that same conversion and shift.
+
+        Both bounds are inclusive: the start snaps to the first instant of its
+        day/month and the end to the last microsecond.
 
         Returns:
             A ``(start, end)`` tuple. Either element is ``None`` when the
@@ -356,10 +364,28 @@ class UsageAggregator:
         if self.date_from is None and self.date_to is None:
             return None, None
 
-        tz_handler = TimezoneHandler(self.timezone)
+        # Match how entry.timestamp is made aware in aggregate() (UTC), and how
+        # the period keys read it, so bounds and keys share one calendar.
+        utc_handler = TimezoneHandler("UTC")
 
-        def make_aware(naive: datetime) -> datetime:
-            return tz_handler.ensure_timezone(naive)
+        daily_reset = (
+            self.aggregation_mode == "daily"
+            and self.reset_hour is not None
+            and self.timezone not in (None, "", "auto")
+        )
+
+        if daily_reset:
+            # Keys bucket in the display tz, shifted back by reset_hour. Build the
+            # bounds in the display tz with the same shift so they line up.
+            tz_handler = TimezoneHandler(self.timezone)
+            shift = timedelta(hours=self.reset_hour or 0)
+
+            def to_bound(naive: datetime) -> datetime:
+                return tz_handler.ensure_timezone(naive + shift)
+        else:
+
+            def to_bound(naive: datetime) -> datetime:
+                return utc_handler.ensure_timezone(naive)
 
         start: Optional[datetime] = None
         end: Optional[datetime] = None
@@ -367,20 +393,20 @@ class UsageAggregator:
         if self.aggregation_mode == "daily":
             if self.date_from is not None:
                 day = datetime.strptime(self.date_from, "%Y-%m-%d")
-                start = make_aware(day)
+                start = to_bound(day)
             if self.date_to is not None:
                 day = datetime.strptime(self.date_to, "%Y-%m-%d")
-                end = make_aware(
+                end = to_bound(
                     day.replace(hour=23, minute=59, second=59, microsecond=999999)
                 )
         else:  # monthly
             if self.date_from is not None:
                 month = datetime.strptime(self.date_from, "%Y-%m")
-                start = make_aware(month)
+                start = to_bound(month)
             if self.date_to is not None:
                 month = datetime.strptime(self.date_to, "%Y-%m")
                 last_day = calendar.monthrange(month.year, month.month)[1]
-                end = make_aware(
+                end = to_bound(
                     month.replace(
                         day=last_day,
                         hour=23,

--- a/src/claude_monitor/data/aggregator.py
+++ b/src/claude_monitor/data/aggregator.py
@@ -4,12 +4,13 @@ This module provides functionality to aggregate Claude usage data
 by day and month, similar to ccusage's functionality.
 """
 
+import calendar
 import logging
 from collections import defaultdict
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Sequence, Union
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
 
 from claude_monitor.core.models import SessionBlock, UsageEntry, normalize_model_name
 from claude_monitor.utils.time_utils import TimezoneHandler
@@ -100,6 +101,8 @@ class UsageAggregator:
         timezone: str = "UTC",
         reset_hour: Optional[int] = None,
         filter_models: str = "all",
+        date_from: Optional[str] = None,
+        date_to: Optional[str] = None,
     ):
         """Initialize the aggregator.
 
@@ -111,12 +114,20 @@ class UsageAggregator:
                 a day runs ``reset_hour`` -> ``reset_hour`` instead of midnight to
                 midnight, so e.g. 02:00 with ``reset_hour=4`` counts toward the
                 previous day. Only affects daily aggregation, not the 5h window.
+            filter_models: Model filter expression passed to the reader.
+            date_from: Inclusive start of the range to aggregate. ``YYYY-MM-DD``
+                for daily mode, ``YYYY-MM`` for monthly mode. ``None`` means no
+                lower bound.
+            date_to: Inclusive end of the range to aggregate, same formats as
+                ``date_from``. ``None`` means no upper bound.
         """
         self.data_path = data_path
         self.aggregation_mode = aggregation_mode
         self.timezone = timezone
         self.reset_hour = reset_hour
         self.filter_models = filter_models
+        self.date_from = date_from
+        self.date_to = date_to
         self.timezone_handler = TimezoneHandler()
 
     def _aggregate_by_period(
@@ -320,9 +331,63 @@ class UsageAggregator:
                 entry.timestamp = self.timezone_handler.ensure_timezone(entry.timestamp)
 
         # Aggregate based on mode
+        start_date, end_date = self._range_bounds()
         if self.aggregation_mode == "daily":
-            return self.aggregate_daily(entries)
+            return self.aggregate_daily(entries, start_date, end_date)
         elif self.aggregation_mode == "monthly":
-            return self.aggregate_monthly(entries)
+            return self.aggregate_monthly(entries, start_date, end_date)
         else:
             raise ValueError(f"Invalid aggregation mode: {self.aggregation_mode}")
+
+    def _range_bounds(self) -> Tuple[Optional[datetime], Optional[datetime]]:
+        """Convert ``date_from``/``date_to`` into timezone-aware boundaries.
+
+        The boundaries are built in the display timezone (``self.timezone``) so a
+        date like ``2026-06-05`` means the user's local June 5th. They are
+        timezone-aware to match ``entry.timestamp`` (made aware in ``aggregate``);
+        comparing aware against naive datetimes would raise. Both bounds are
+        inclusive: the start snaps to the first instant of its day/month and the
+        end to the last microsecond of its day/month.
+
+        Returns:
+            A ``(start, end)`` tuple. Either element is ``None`` when the
+            corresponding flag is unset (one-sided ranges).
+        """
+        if self.date_from is None and self.date_to is None:
+            return None, None
+
+        tz_handler = TimezoneHandler(self.timezone)
+
+        def make_aware(naive: datetime) -> datetime:
+            return tz_handler.ensure_timezone(naive)
+
+        start: Optional[datetime] = None
+        end: Optional[datetime] = None
+
+        if self.aggregation_mode == "daily":
+            if self.date_from is not None:
+                day = datetime.strptime(self.date_from, "%Y-%m-%d")
+                start = make_aware(day)
+            if self.date_to is not None:
+                day = datetime.strptime(self.date_to, "%Y-%m-%d")
+                end = make_aware(
+                    day.replace(hour=23, minute=59, second=59, microsecond=999999)
+                )
+        else:  # monthly
+            if self.date_from is not None:
+                month = datetime.strptime(self.date_from, "%Y-%m")
+                start = make_aware(month)
+            if self.date_to is not None:
+                month = datetime.strptime(self.date_to, "%Y-%m")
+                last_day = calendar.monthrange(month.year, month.month)[1]
+                end = make_aware(
+                    month.replace(
+                        day=last_day,
+                        hour=23,
+                        minute=59,
+                        second=59,
+                        microsecond=999999,
+                    )
+                )
+
+        return start, end

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -400,6 +400,121 @@ class TestUsageAggregator:
         assert len(result) == 1
         assert result[0]["month"] == "2024-02"
 
+    def test_aggregate_with_date_from_to_daily(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """``date_from``/``date_to`` restrict the daily view to that range."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="daily",
+            timezone="UTC",
+            date_from="2024-01-15",
+            date_to="2024-01-31",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
+
+        # Only Jan 15 and Jan 31 fall in the inclusive window.
+        assert [row["date"] for row in result] == ["2024-01-15", "2024-01-31"]
+
+    def test_aggregate_date_range_boundaries_inclusive_daily(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """Both range boundaries are inclusive for the daily view."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="daily",
+            timezone="UTC",
+            date_from="2024-01-31",
+            date_to="2024-01-31",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
+
+        # The boundary day itself is included (entries exist at 10:00 and 14:00).
+        assert [row["date"] for row in result] == ["2024-01-31"]
+
+    def test_aggregate_with_date_from_only_daily(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """A one-sided ``date_from`` keeps everything on/after that day."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="daily",
+            timezone="UTC",
+            date_from="2024-02-01",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        assert end_date is None
+        result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
+
+        assert [row["date"] for row in result] == [
+            "2024-02-01",
+            "2024-02-15",
+            "2024-02-29",
+        ]
+
+    def test_aggregate_with_date_to_only_daily(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """A one-sided ``date_to`` keeps everything on/before that day."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="daily",
+            timezone="UTC",
+            date_to="2024-01-02",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        assert start_date is None
+        result = aggregator.aggregate_daily(sample_entries, start_date, end_date)
+
+        assert [row["date"] for row in result] == ["2024-01-01", "2024-01-02"]
+
+    def test_aggregate_with_date_from_to_monthly(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """``date_from``/``date_to`` restrict the monthly view to that range."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="monthly",
+            timezone="UTC",
+            date_from="2024-02",
+            date_to="2024-02",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        result = aggregator.aggregate_monthly(sample_entries, start_date, end_date)
+
+        # February's last day (29th, leap year) must be inside the upper bound.
+        assert [row["month"] for row in result] == ["2024-02"]
+        assert result[0]["entries_count"] == 3
+
+    def test_aggregate_monthly_upper_bound_includes_month_end(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """The monthly upper bound spans to the final day of the month."""
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="monthly",
+            timezone="UTC",
+            date_from="2024-01",
+            date_to="2024-01",
+        )
+        _, end_date = aggregator._range_bounds()
+        assert end_date is not None
+        # January ends on the 31st at the last microsecond.
+        assert end_date.year == 2024
+        assert end_date.month == 1
+        assert end_date.day == 31
+
+    def test_range_bounds_none_when_unset(
+        self, sample_entries: List[UsageEntry]
+    ) -> None:
+        """No range flags yields no bounds and the full result set."""
+        aggregator = UsageAggregator(
+            data_path=".", aggregation_mode="daily", timezone="UTC"
+        )
+        assert aggregator._range_bounds() == (None, None)
+
     def test_aggregate_from_blocks_daily(
         self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
     ) -> None:

--- a/src/tests/test_aggregator.py
+++ b/src/tests/test_aggregator.py
@@ -515,6 +515,49 @@ class TestUsageAggregator:
         )
         assert aggregator._range_bounds() == (None, None)
 
+    def test_range_bounds_use_utc_calendar_for_non_utc_timezone(self) -> None:
+        """Bounds follow the UTC period keys, not the display timezone.
+
+        The default daily key formats the raw UTC timestamp, so a range is
+        interpreted on the UTC calendar even when the display timezone differs.
+        An entry at 02:00 UTC on Jan 2 belongs to UTC Jan 2 (the key is
+        ``2024-01-02``) and must be kept; an entry at 23:00 UTC on Jan 1 belongs
+        to UTC Jan 1 and must be dropped by ``date_from="2024-01-02"`` -- even
+        though both fall on Jan 1 in America/New_York local time.
+        """
+
+        def _entry(ts: datetime, suffix: str) -> UsageEntry:
+            return UsageEntry(
+                timestamp=ts,
+                input_tokens=100,
+                output_tokens=50,
+                cache_creation_tokens=10,
+                cache_read_tokens=5,
+                cost_usd=0.001,
+                model="claude-3-haiku",
+                message_id=f"msg_{suffix}",
+                request_id=f"req_{suffix}",
+            )
+
+        entries = [
+            _entry(datetime(2024, 1, 1, 23, 0, tzinfo=timezone.utc), "before"),
+            _entry(datetime(2024, 1, 2, 2, 0, tzinfo=timezone.utc), "after"),
+        ]
+
+        aggregator = UsageAggregator(
+            data_path=".",
+            aggregation_mode="daily",
+            timezone="America/New_York",
+            date_from="2024-01-02",
+            date_to="2024-01-02",
+        )
+        start_date, end_date = aggregator._range_bounds()
+        result = aggregator.aggregate_daily(entries, start_date, end_date)
+
+        # Only the UTC-Jan-2 entry survives; the bound matches the UTC key.
+        assert [row["date"] for row in result] == ["2024-01-02"]
+        assert result[0]["entries_count"] == 1
+
     def test_aggregate_from_blocks_daily(
         self, aggregator: UsageAggregator, sample_entries: List[UsageEntry]
     ) -> None:

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -969,6 +969,36 @@ class TestDateRangeFlags:
         with pytest.raises(ValidationError):
             Settings(view="daily", date_from="2026-13-01", _cli_parse_args=[])
 
+    def test_daily_rejects_non_canonical_date(self) -> None:
+        """Daily view rejects non-zero-padded input that strptime would accept."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="daily", date_from="2026-6-1", _cli_parse_args=[])
+
+    def test_monthly_rejects_non_canonical_month(self) -> None:
+        """Monthly view rejects non-zero-padded months like ``2026-6``."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="monthly", date_from="2026-6", _cli_parse_args=[])
+
+    def test_monthly_from_after_to_uses_parsed_order(self) -> None:
+        """``2026-10`` > ``2026-6`` must be caught via parsed comparison.
+
+        A raw string comparison would order ``"2026-10" < "2026-6"`` and miss
+        this inverted range; comparing parsed datetimes rejects it correctly.
+        """
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(
+                view="monthly",
+                date_from="2026-10",
+                date_to="2026-06",
+                _cli_parse_args=[],
+            )
+
     def test_monthly_accepts_month_format(self) -> None:
         """Monthly view accepts ``YYYY-MM`` boundaries."""
         settings = Settings(

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -941,6 +941,115 @@ class TestSettings:
             Settings(data_paths=["/a", "  "], _cli_parse_args=[])
 
 
+class TestDateRangeFlags:
+    """Tests for the ``--from``/``--to`` date-range flags."""
+
+    def test_daily_accepts_iso_date(self) -> None:
+        """Daily view accepts ``YYYY-MM-DD`` boundaries."""
+        settings = Settings(
+            view="daily",
+            date_from="2026-06-01",
+            date_to="2026-06-05",
+            _cli_parse_args=[],
+        )
+        assert settings.date_from == "2026-06-01"
+        assert settings.date_to == "2026-06-05"
+
+    def test_daily_rejects_month_format(self) -> None:
+        """Daily view rejects the ``YYYY-MM`` month format."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="daily", date_from="2026-06", _cli_parse_args=[])
+
+    def test_daily_rejects_invalid_calendar_date(self) -> None:
+        """Daily view rejects impossible dates such as month 13."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="daily", date_from="2026-13-01", _cli_parse_args=[])
+
+    def test_monthly_accepts_month_format(self) -> None:
+        """Monthly view accepts ``YYYY-MM`` boundaries."""
+        settings = Settings(
+            view="monthly",
+            date_from="2026-06",
+            date_to="2026-07",
+            _cli_parse_args=[],
+        )
+        assert settings.date_from == "2026-06"
+        assert settings.date_to == "2026-07"
+
+    def test_monthly_rejects_day_format(self) -> None:
+        """Monthly view rejects the ``YYYY-MM-DD`` day format."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="monthly", date_from="2026-06-01", _cli_parse_args=[])
+
+    def test_range_rejected_for_non_table_view(self) -> None:
+        """The flags only apply to the daily and monthly views."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(view="realtime", date_from="2026-06-01", _cli_parse_args=[])
+
+    def test_from_after_to_rejected(self) -> None:
+        """``--from`` must not be later than ``--to``."""
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            Settings(
+                view="daily",
+                date_from="2026-06-05",
+                date_to="2026-06-01",
+                _cli_parse_args=[],
+            )
+
+    def test_one_sided_ranges_allowed(self) -> None:
+        """Either boundary may be omitted."""
+        only_from = Settings(view="daily", date_from="2026-06-05", _cli_parse_args=[])
+        assert only_from.date_from == "2026-06-05"
+        assert only_from.date_to is None
+
+        only_to = Settings(view="monthly", date_to="2026-06", _cli_parse_args=[])
+        assert only_to.date_from is None
+        assert only_to.date_to == "2026-06"
+
+    def test_no_range_is_default(self) -> None:
+        """Without the flags both boundaries default to ``None``."""
+        settings = Settings(view="realtime", _cli_parse_args=[])
+        assert settings.date_from is None
+        assert settings.date_to is None
+
+    def test_cli_from_to_aliases_parse(self) -> None:
+        """The ``--from``/``--to`` CLI tokens map onto the fields."""
+        settings = Settings(
+            _cli_parse_args=[
+                "--view",
+                "daily",
+                "--from",
+                "2026-06-01",
+                "--to",
+                "2026-06-05",
+            ]
+        )
+        assert settings.date_from == "2026-06-01"
+        assert settings.date_to == "2026-06-05"
+
+    def test_to_namespace_carries_date_range(self) -> None:
+        """The range values are plumbed into the argparse namespace."""
+        settings = Settings(
+            view="daily",
+            date_from="2026-06-01",
+            date_to="2026-06-05",
+            _cli_parse_args=[],
+        )
+        namespace = settings.to_namespace()
+        assert namespace.date_from == "2026-06-01"
+        assert namespace.date_to == "2026-06-05"
+
+
 class TestSettingsIntegration:
     """Integration tests for Settings class."""
 

--- a/src/tests/test_settings.py
+++ b/src/tests/test_settings.py
@@ -617,6 +617,51 @@ class TestSettings:
 
     @patch("claude_monitor.core.settings.Settings._get_system_timezone")
     @patch("claude_monitor.core.settings.Settings._get_system_time_format")
+    def test_load_with_last_used_range_uses_saved_view(
+        self, mock_time_format: Mock, mock_timezone: Mock
+    ) -> None:
+        """--from/--to validate against the saved view, not the default realtime."""
+        mock_timezone.return_value = "UTC"
+        mock_time_format.return_value = "24h"
+
+        with patch("claude_monitor.core.settings.LastUsedParams") as MockLastUsed:
+            mock_instance = Mock()
+            mock_instance.load.return_value = {"view": "daily"}
+            MockLastUsed.return_value = mock_instance
+
+            # No --view on the CLI; the saved daily view must apply before the
+            # date-range validator runs, so this does not raise.
+            settings = Settings.load_with_last_used(
+                ["--from", "2026-06-01", "--to", "2026-06-30"]
+            )
+
+            assert settings.view == "daily"
+            assert settings.date_from == "2026-06-01"
+            assert settings.date_to == "2026-06-30"
+
+    @patch("claude_monitor.core.settings.Settings._get_system_timezone")
+    @patch("claude_monitor.core.settings.Settings._get_system_time_format")
+    def test_load_with_last_used_cli_view_overrides_saved_for_range(
+        self, mock_time_format: Mock, mock_timezone: Mock
+    ) -> None:
+        """An explicit --view still wins over the saved view during replay."""
+        mock_timezone.return_value = "UTC"
+        mock_time_format.return_value = "24h"
+
+        with patch("claude_monitor.core.settings.LastUsedParams") as MockLastUsed:
+            mock_instance = Mock()
+            mock_instance.load.return_value = {"view": "daily"}
+            MockLastUsed.return_value = mock_instance
+
+            settings = Settings.load_with_last_used(
+                ["--view", "monthly", "--from", "2026-06"]
+            )
+
+            assert settings.view == "monthly"
+            assert settings.date_from == "2026-06"
+
+    @patch("claude_monitor.core.settings.Settings._get_system_timezone")
+    @patch("claude_monitor.core.settings.Settings._get_system_time_format")
     def test_load_with_last_used_cli_plan_overrides_saved(
         self, mock_time_format: Mock, mock_timezone: Mock
     ) -> None:


### PR DESCRIPTION
## Summary

Adds `--from`/`--to` to restrict the `daily` and `monthly` tables to an inclusive date range.

Format follows the view: `daily` takes `YYYY-MM-DD`, `monthly` takes `YYYY-MM`. Either bound works alone. The flags only apply to those two views — using them elsewhere is a validation error.

Most of the plumbing already existed. `UsageAggregator` accepts `start_date`/`end_date` and filters on the entry timestamp; the public `aggregate()` just never passed them. So this connects the flags to that filter instead of writing new aggregation. The totals row and period header follow automatically, since both come from the rows the aggregator returns.

One thing reviewers should know: these views read `~/.claude/projects/`, which Claude Code prunes after `cleanupPeriodDays` (default 30). A range older than that returns no rows, not an error. The README explains how to raise the retention for longer monthly history.

Changes: the validated `--from`/`--to` fields on `Settings`, a `_range_bounds()` helper that builds timezone-aware inclusive bound (month-end via `calendar.monthrange`), tests for both views including boundary inclusivity and the error cases, and the README entries.

Closes #223 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional `--from` / `--to` date-range filters for daily and monthly table views (aliases supported).
  * Filtering is inclusive and applied during aggregation; supports one-sided ranges.
* **Bug Fixes**
  * Enforces correct ISO formats per view, validates calendar dates, and rejects invalid/ordered ranges and unsupported views.
  * Bounds are interpreted using UTC-based daily keys even when display timezone is non-UTC; date-range replay now respects saved view vs explicitly provided view.
* **Documentation**
  * Updated README with a “Filtering daily/monthly views by date range” section, examples, and retention notes.
* **Tests**
  * Added coverage for inclusive bounds, edge cases (including leap years), and timezone/key behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->