### PR TITLE
fix: recognize Fable 5 model family in usage display

### DIFF
--- a/src/claude_monitor/core/models.py
+++ b/src/claude_monitor/core/models.py
@@ -167,6 +167,8 @@ def normalize_model_name(model: str) -> str:
         if "3.5" in model_lower or "3-5" in model_lower:
             return "claude-3-5-haiku"
         return "claude-3-haiku"
+    if "fable" in model_lower:
+        return model_lower
 
     return model
 

--- a/src/claude_monitor/ui/progress_bars.py
+++ b/src/claude_monitor/ui/progress_bars.py
@@ -268,6 +268,7 @@ class ModelUsageBar(BaseProgressBar):
     _FAMILY_STYLES: Final[dict[str, str]] = {
         "Sonnet": "info",
         "Opus": "warning",
+        "Fable": "highlight",
         "Haiku": "success",
         "Other": "dim",
     }
@@ -279,6 +280,8 @@ class ModelUsageBar(BaseProgressBar):
             return "Sonnet"
         if "opus" in name:
             return "Opus"
+        if "fable" in name:
+            return "Fable"
         if "haiku" in name:
             return "Haiku"
         return "Other"

--- a/src/tests/test_formatting.py
+++ b/src/tests/test_formatting.py
@@ -441,6 +441,10 @@ class TestModelUtils:
         assert normalize_model_name("Claude 3.5 Sonnet") == "claude-3-5-sonnet"
         assert normalize_model_name("claude-3-5-haiku") == "claude-3-5-haiku"
 
+        # Test Claude 5 models
+        assert normalize_model_name("claude-fable-5") == "claude-fable-5"
+        assert normalize_model_name("Claude-Fable-5") == "claude-fable-5"
+
         # Test empty/None inputs
         assert normalize_model_name("") == ""
         assert normalize_model_name(None) == ""

--- a/src/tests/test_progress_bars.py
+++ b/src/tests/test_progress_bars.py
@@ -34,6 +34,20 @@ def test_render_lists_every_present_family() -> None:
         assert family in out
 
 
+def test_render_fable_family_recognized_not_other() -> None:
+    """Fable 5 usage shows under its own family name, not as 'Other'."""
+    bar = ModelUsageBar(width=50)
+    out = bar.render(
+        {
+            "claude-fable-5": _tokens(70),
+            "claude-sonnet-4-5": _tokens(30),
+        }
+    )
+    assert "Fable" in out and "70.0%" in out
+    assert "Sonnet" in out and "30.0%" in out
+    assert "Other" not in out
+
+
 def test_render_unknown_family_shown_as_other_not_dropped() -> None:
     """An unmapped family still appears (as 'Other'); its share is not silently lost."""
     bar = ModelUsageBar(width=50)


### PR DESCRIPTION
## Problem

When all usage comes from `claude-fable-5` (Anthropic's new Claude 5 family), the model usage bar shows **"Other 100%"** instead of naming the model family. `ModelUsageBar._family_for()` only knew Sonnet, Opus, and Haiku, so Fable fell into the "Other" fallback bucket.

Pricing already handles Fable (`core/pricing.py` has a `fable` rate entry); only the display classification was behind.

## Changes

- `ui/progress_bars.py`: add a `Fable` family to `_FAMILY_STYLES` (styled `highlight`, which is defined in all three themes) and match `fable` in `_family_for()`.
- `core/models.py`: pass Fable model ids through `normalize_model_name()` lowercased, matching the existing 4-series behavior.
- Tests for both: Fable renders as its own family (not "Other"), and normalization is covered in `test_normalize_model_name`.

## Testing

`pytest src/tests`: 730 passed, 3 skipped. Also verified against live usage data from a Fable 5 session — the bar now shows `Fable 100.0%`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for Fable model names, including consistent recognition of lowercase and mixed-case variants.
  - Fable models now appear under the **Fable** category in usage progress bars, with token usage and percentages displayed correctly.

- **Bug Fixes**
  - Corrected model-name normalization so Fable model names are consistently identified and formatted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->