### PR TITLE
Fix pricing cache/shared-dict bugs and a mistyped terminal error handler

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ classifiers = [
   "Operating System :: OS Independent",
   "Operating System :: POSIX :: Linux",
   "Operating System :: MacOS",
-#  "Operating System :: Microsoft :: Windows",
+  "Operating System :: Microsoft :: Windows",
   "Typing :: Typed"
 ]
 dependencies = [

--- a/src/claude_monitor/core/pricing.py
+++ b/src/claude_monitor/core/pricing.py
@@ -170,10 +170,12 @@ class PricingCalculator:
             cache_creation_tokens = tokens.cache_creation_tokens
             cache_read_tokens = tokens.cache_read_tokens
 
-        # Create cache key
+        # Create cache key (strict is included: a strict=False lookup for an
+        # unknown model must not shadow a later strict=True lookup for the
+        # same tokens, or the KeyError would be silently skipped).
         cache_key = (
             f"{model}:{input_tokens}:{output_tokens}:"
-            f"{cache_creation_tokens}:{cache_read_tokens}"
+            f"{cache_creation_tokens}:{cache_read_tokens}:{strict}"
         )
 
         # Check cache
@@ -200,6 +202,24 @@ class PricingCalculator:
         self._cost_cache[cache_key] = cost
         return cost
 
+    def _ensure_cache_pricing(self, key: str) -> Dict[str, float]:
+        """Return self.pricing[key] guaranteed to have cache fields.
+
+        Several keys (e.g. the claude-opus-4-5..4-8 aliases) point at the
+        *same* FALLBACK_PRICING dict object. Filling in missing cache fields
+        in place would mutate that shared object for every alias (and, for
+        FALLBACK_PRICING itself, globally). Copy-on-write instead: only
+        allocate a new dict when a field is actually missing.
+        """
+        pricing = self.pricing[key]
+        if "cache_creation" in pricing and "cache_read" in pricing:
+            return pricing
+        pricing = dict(pricing)
+        pricing.setdefault("cache_creation", pricing["input"] * 1.25)
+        pricing.setdefault("cache_read", pricing["input"] * 0.1)
+        self.pricing[key] = pricing
+        return pricing
+
     def _get_pricing_for_model(
         self, model: str, strict: bool = False
     ) -> Dict[str, float]:
@@ -220,21 +240,12 @@ class PricingCalculator:
 
         # Check configured pricing
         if normalized in self.pricing:
-            pricing = self.pricing[normalized]
-            # Ensure cache pricing exists
-            if "cache_creation" not in pricing:
-                pricing["cache_creation"] = pricing["input"] * 1.25
-            if "cache_read" not in pricing:
-                pricing["cache_read"] = pricing["input"] * 0.1
+            pricing = self._ensure_cache_pricing(normalized)
             return pricing
 
         # Check original model name
         if model in self.pricing:
-            pricing = self.pricing[model]
-            if "cache_creation" not in pricing:
-                pricing["cache_creation"] = pricing["input"] * 1.25
-            if "cache_read" not in pricing:
-                pricing["cache_read"] = pricing["input"] * 0.1
+            pricing = self._ensure_cache_pricing(model)
             return pricing
 
         # If strict mode, raise KeyError for unknown models

--- a/src/claude_monitor/error_handling.py
+++ b/src/claude_monitor/error_handling.py
@@ -47,10 +47,17 @@ def report_error(
             exc_info=True,
             extra=extra_data,
         )
-    except Exception:
-        # If logging itself fails, we can't do much more than silently continue
-        # to avoid cascading failures
-        pass
+    except Exception as logging_error:
+        # If logging itself fails, we can't do much more than continue to
+        # avoid cascading failures, but write a last-resort line to stderr
+        # so a misconfigured logger isn't completely invisible.
+        try:
+            sys.stderr.write(
+                f"[{component}] failed to log error ({logging_error}): "
+                f"{exception}\n"
+            )
+        except Exception:
+            pass
 
 
 def report_file_error(

--- a/src/claude_monitor/terminal/manager.py
+++ b/src/claude_monitor/terminal/manager.py
@@ -4,7 +4,7 @@ Raw mode setup, input handling, and terminal control.
 
 import logging
 import sys
-from typing import Any, List, Optional, Union
+from typing import Any, List, Optional
 
 from claude_monitor.error_handling import report_error
 from claude_monitor.terminal.themes import print_themed
@@ -90,13 +90,13 @@ def handle_cleanup_and_exit(
 
 
 def handle_error_and_exit(
-    old_terminal_settings: Optional[List[Any]], error: Union[Exception, str]
+    old_terminal_settings: Optional[List[Any]], error: Exception
 ) -> None:
     """Handle error cleanup and exit.
 
     Args:
         old_terminal_settings: Terminal settings to restore before exit.
-        error: Exception or error message that caused the exit.
+        error: Exception that caused the exit.
 
     Raises:
         The original error after cleanup and reporting.


### PR DESCRIPTION
## Summary

Found while doing a source-level audit of `core/pricing.py`, `error_handling.py`, and `terminal/manager.py`. No behavior change for the currently-shipped pricing tables, but these are latent correctness bugs:

- **`core/pricing.py` — cache key ignored `strict`.** `calculate_cost`'s cache key was `f"{model}:{input}:{output}:{cache_creation}:{cache_read}"`, without `strict`. A `strict=False` lookup for an unknown model caches a `$0` result; a later `strict=True` lookup for the *same* token counts then silently returns that cached value instead of raising `KeyError`. Fixed by including `strict` in the cache key.
- **`core/pricing.py` — shared pricing dicts mutated in place.** Several model aliases (`claude-opus-4-5` .. `claude-opus-4-8`, etc.) are assigned the *same* `FALLBACK_PRICING["opus"]` dict object in `self.pricing`. `_get_pricing_for_model` filled in missing `cache_creation`/`cache_read` keys by mutating that dict in place, so the fix could leak across every alias sharing the object (and into `FALLBACK_PRICING` itself) the first time a pricing dict without those fields was used — e.g. via `custom_pricing`. Replaced with a small copy-on-write helper (`_ensure_cache_pricing`) that only allocates a new dict when a field is actually missing.
- **`terminal/manager.py` — `handle_error_and_exit` typed `Union[Exception, str]` but always does `raise error`.** Passing a `str` would raise `TypeError: exceptions must derive from BaseException`, masking the original error. The only caller (`cli/main.py`) always passes an `Exception`, so the `str` branch was dead and misleading; narrowed the type to `Exception`.
- **`error_handling.py` — silent `except Exception: pass` in the logging fallback.** If the logger call itself fails, the original error vanished with zero trace. Now writes a last-resort line to `stderr` before falling back to `pass`.
- **`pyproject.toml` — uncommented the `Operating System :: Microsoft :: Windows` classifier**, which was inconsistent with the existing win32-specific `tzdata`/`tzlocal` dependencies and the dedicated WSL path support/tests already in the codebase.

## Test plan

- [x] `pytest src/tests/test_pricing.py src/tests/test_error_handling.py` — all green
- [x] Full suite (`pytest src/tests`) — same 15 pre-existing failures as on unmodified `main` (Windows/Python 3.14 locale & signal environment issues, verified via `git stash` comparison), no new failures introduced
- [x] `mypy` on the touched files — no new errors (pre-existing `HAS_TERMIOS` redefinition warnings in `themes.py`/`manager.py` are unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pricing cache behavior so strict and non-strict calculations return the correct costs.
  * Prevented pricing data from being unintentionally modified when cache details are added.
  * Improved error reporting with a fallback message when primary logging fails.
* **Compatibility**
  * Windows support is now correctly reflected in package metadata.
* **Maintenance**
  * Clarified terminal error-handling requirements for more consistent failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->