### PR TITLE
fix(reader): keep the complete record when a message spans several JSONL lines

### DIFF
--- a/src/claude_monitor/data/reader.py
+++ b/src/claude_monitor/data/reader.py
@@ -100,14 +100,14 @@ def load_usage_entries(
 
     all_entries: List[UsageEntry] = []
     raw_entries: Optional[List[Dict[str, Any]]] = [] if include_raw else None
-    processed_hashes: Set[str] = set()
+    deduped: Dict[str, UsageEntry] = {}
 
     for file_path, source in files_by_source:
         entries, raw_data = _process_single_file(
             file_path,
             mode,
             cutoff_time,
-            processed_hashes,
+            deduped,
             include_raw,
             timezone_handler,
             pricing_calculator,
@@ -116,6 +116,8 @@ def load_usage_entries(
         all_entries.extend(entries)
         if include_raw and raw_data:
             raw_entries.extend(raw_data)
+
+    all_entries.extend(deduped.values())
 
     if filter_models == "anthropic":
         before = len(all_entries)
@@ -174,13 +176,19 @@ def _process_single_file(
     file_path: Path,
     mode: CostMode,
     cutoff_time: Optional[datetime],
-    processed_hashes: Set[str],
+    deduped: Dict[str, UsageEntry],
     include_raw: bool,
     timezone_handler: TimezoneHandler,
     pricing_calculator: PricingCalculator,
     source: Optional[Dict[str, Any]] = None,
 ) -> Tuple[List[UsageEntry], Optional[List[Dict[str, Any]]]]:
-    """Process a single JSONL file."""
+    """Process a single JSONL file.
+
+    ``deduped`` is shared across every file of the scan and holds the winning
+    record for each dedup key, so a key restated in a later file is resolved
+    against the earlier one instead of being dropped. Records without a key are
+    returned directly, since they were never deduplicated.
+    """
     entries: List[UsageEntry] = []
     raw_data: Optional[List[Dict[str, Any]]] = [] if include_raw else None
 
@@ -199,21 +207,30 @@ def _process_single_file(
                     data = json.loads(line)
                     entries_read += 1
 
-                    if not _should_process_entry(
-                        data, cutoff_time, processed_hashes, timezone_handler
-                    ):
+                    if not _should_process_entry(data, cutoff_time, timezone_handler):
                         entries_filtered += 1
                         continue
 
                     entry = _map_to_usage_entry(
                         data, mode, timezone_handler, pricing_calculator, source
                     )
-                    if entry:
-                        entries_mapped += 1
-                        entries.append(entry)
-                        _update_processed_hashes(data, processed_hashes)
 
-                    if include_raw:
+                    unique_hash = _create_unique_hash(data)
+                    first_sighting = unique_hash is None or unique_hash not in deduped
+
+                    if entry:
+                        if unique_hash is None:
+                            entries_mapped += 1
+                            entries.append(entry)
+                        elif first_sighting:
+                            entries_mapped += 1
+                            deduped[unique_hash] = entry
+                        else:
+                            entries_filtered += 1
+                            if _replaces_existing(entry, deduped[unique_hash]):
+                                deduped[unique_hash] = entry
+
+                    if include_raw and first_sighting:
                         raw_entry = dict(data)
                         if source is not None:
                             raw_entry["source"] = source
@@ -244,10 +261,16 @@ def _process_single_file(
 def _should_process_entry(
     data: Dict[str, Any],
     cutoff_time: Optional[datetime],
-    processed_hashes: Set[str],
     timezone_handler: TimezoneHandler,
 ) -> bool:
-    """Check if entry should be processed based on time and uniqueness."""
+    """Check whether an entry falls inside the requested time window.
+
+    Records sharing a dedup key are no longer rejected here. A streaming
+    message is written as several records under one key and the earlier ones
+    carry a partial usage snapshot, so skipping everything after the first
+    would keep the partial record. Selection among records that share a key
+    happens in :func:`_replaces_existing`, after both have been mapped.
+    """
     if cutoff_time:
         timestamp_str = data.get("timestamp")
         if timestamp_str:
@@ -256,8 +279,7 @@ def _should_process_entry(
             if timestamp and timestamp < cutoff_time:
                 return False
 
-    unique_hash = _create_unique_hash(data)
-    return not (unique_hash and unique_hash in processed_hashes)
+    return True
 
 
 def _create_unique_hash(data: Dict[str, Any]) -> Optional[str]:
@@ -272,11 +294,33 @@ def _create_unique_hash(data: Dict[str, Any]) -> Optional[str]:
     return f"{message_id}:{request_id}" if message_id and request_id else None
 
 
-def _update_processed_hashes(data: Dict[str, Any], processed_hashes: Set[str]) -> None:
-    """Update the processed hashes set with current entry's hash."""
-    unique_hash = _create_unique_hash(data)
-    if unique_hash:
-        processed_hashes.add(unique_hash)
+def _replaces_existing(candidate: UsageEntry, incumbent: UsageEntry) -> bool:
+    """Decide which of two records sharing a dedup key is the complete one.
+
+    Streaming writes several records per message under one key, each carrying
+    the usage observed so far, so the counters are monotone within a key and
+    the largest record is the finished one. Selecting on the maximum rather
+    than on the last record read matters because files are discovered through
+    an unordered traversal: a key restated across two files after a session
+    resume would otherwise resolve to whichever file the filesystem happened
+    to hand over first.
+
+    The winning record is kept whole. Taking a per-field maximum could
+    assemble a record that was never written, and ``cost_usd`` is derived from
+    those fields, so the resulting cost would correspond to no observation.
+    """
+    if candidate.output_tokens != incumbent.output_tokens:
+        return candidate.output_tokens > incumbent.output_tokens
+
+    def _total(entry: UsageEntry) -> int:
+        return (
+            entry.input_tokens
+            + entry.output_tokens
+            + entry.cache_creation_tokens
+            + entry.cache_read_tokens
+        )
+
+    return _total(candidate) > _total(incumbent)
 
 
 def _extract_project(data: Dict[str, Any]) -> str:

--- a/src/tests/test_data_reader.py
+++ b/src/tests/test_data_reader.py
@@ -9,7 +9,7 @@ import json
 import tempfile
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Tuple
+from typing import Any, Dict, Tuple
 from unittest.mock import Mock, mock_open, patch
 
 import pytest
@@ -21,8 +21,8 @@ from claude_monitor.data.reader import (
     _find_jsonl_files,
     _map_to_usage_entry,
     _process_single_file,
+    _replaces_existing,
     _should_process_entry,
-    _update_processed_hashes,
     load_all_raw_entries,
     load_usage_entries,
 )
@@ -135,7 +135,7 @@ class TestLoadUsageEntries:
     def test_load_usage_entries_accepts_multiple_paths_dedups_and_tags_source(
         self, tmp_path: Path
     ) -> None:
-        """Multiple roots share one processed_hashes set and tag each entry source."""
+        """Multiple roots share one winners map and tag each entry source."""
         first = tmp_path / "home" / "projects"
         second = tmp_path / "work" / "projects"
         duplicate = {
@@ -194,6 +194,73 @@ class TestLoadUsageEntries:
             call_args = mock_find.call_args[0]
             path_str = str(call_args[0])
             assert ".claude/projects" in path_str
+
+
+class TestStreamingRecordSelection:
+    """The two transcript shapes written under a single dedup key.
+
+    Main transcripts repeat the final usage on every record, so any selection
+    rule agrees. Subagent transcripts write true streaming snapshots where only
+    the last record is complete, so keeping the first loses most of the output.
+    The two are pinned as separate fixtures rather than averaged, because a
+    blended figure hides the second shape behind the first.
+    """
+
+    @staticmethod
+    def _write_jsonl(path: Path, rows: list[dict[str, Any]]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+    @staticmethod
+    def _record(output_tokens: int, *, input_tokens: int = 40) -> dict[str, Any]:
+        return {
+            "timestamp": "2024-01-01T12:00:00Z",
+            "message_id": "msg-stream",
+            "requestId": "req-stream",
+            "model": "claude-3-haiku",
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+        }
+
+    def test_main_shape_counts_the_message_once(self, tmp_path: Path) -> None:
+        """Usage identical on every record: one entry carrying that usage."""
+        self._write_jsonl(
+            tmp_path / "projects" / "main.jsonl",
+            [self._record(2400), self._record(2400), self._record(2400)],
+        )
+
+        entries, _ = load_usage_entries(data_path=str(tmp_path / "projects"))
+
+        assert len(entries) == 1
+        assert entries[0].output_tokens == 2400
+
+    def test_subagent_shape_keeps_the_complete_record(self, tmp_path: Path) -> None:
+        """Partial snapshots first, complete last: the complete one survives."""
+        self._write_jsonl(
+            tmp_path / "projects" / "subagent.jsonl",
+            [self._record(3), self._record(870), self._record(2400)],
+        )
+
+        entries, _ = load_usage_entries(data_path=str(tmp_path / "projects"))
+
+        assert len(entries) == 1
+        assert entries[0].output_tokens == 2400
+
+    def test_selection_does_not_depend_on_traversal_order(self, tmp_path: Path) -> None:
+        """A key restated across files must resolve the same either way.
+
+        File discovery is an unordered traversal, so a resume that restates a
+        key in a second file would otherwise resolve to whichever file the
+        filesystem happened to hand over first.
+        """
+        root = tmp_path / "projects"
+        self._write_jsonl(root / "a.jsonl", [self._record(2400)])
+        self._write_jsonl(root / "b.jsonl", [self._record(3)])
+
+        entries, _ = load_usage_entries(data_path=str(root))
+
+        assert len(entries) == 1
+        assert entries[0].output_tokens == 2400
 
 
 class TestLoadAllRawEntries:
@@ -345,20 +412,22 @@ class TestProcessSingleFile:
                 "claude_monitor.data.reader._map_to_usage_entry",
                 return_value=sample_entry,
             ),
-            patch("claude_monitor.data.reader._update_processed_hashes"),
         ):
+            deduped: Dict[str, UsageEntry] = {}
             entries, raw_data = _process_single_file(
                 test_file,
                 CostMode.AUTO,
                 None,  # cutoff_time
-                set(),  # processed_hashes
+                deduped,
                 True,  # include_raw
                 timezone_handler,
                 pricing_calculator,
             )
 
-        assert len(entries) == 1
-        assert entries[0] == sample_entry
+        # A record carrying a dedup key lands in the shared winners map, not in
+        # the returned list, so a later file can still replace it.
+        assert entries == []
+        assert list(deduped.values()) == [sample_entry]
         assert len(raw_data) == 1
         assert raw_data[0] == sample_data[0]
 
@@ -387,13 +456,12 @@ class TestProcessSingleFile:
                 "claude_monitor.data.reader._map_to_usage_entry",
                 return_value=sample_entry,
             ),
-            patch("claude_monitor.data.reader._update_processed_hashes"),
         ):
             entries, raw_data = _process_single_file(
                 test_file,
                 CostMode.AUTO,
                 None,
-                set(),
+                {},
                 False,
                 timezone_handler,
                 pricing_calculator,
@@ -419,7 +487,7 @@ class TestProcessSingleFile:
                 test_file,
                 CostMode.AUTO,
                 None,
-                set(),
+                {},
                 True,
                 timezone_handler,
                 pricing_calculator,
@@ -445,7 +513,7 @@ class TestProcessSingleFile:
                 test_file,
                 CostMode.AUTO,
                 None,
-                set(),
+                {},
                 True,
                 timezone_handler,
                 pricing_calculator,
@@ -464,7 +532,7 @@ class TestProcessSingleFile:
                     test_file,
                     CostMode.AUTO,
                     None,
-                    set(),
+                    {},
                     True,
                     timezone_handler,
                     pricing_calculator,
@@ -492,7 +560,7 @@ class TestProcessSingleFile:
                 test_file,
                 CostMode.AUTO,
                 None,
-                set(),
+                {},
                 True,
                 timezone_handler,
                 pricing_calculator,
@@ -517,7 +585,7 @@ class TestShouldProcessEntry:
         with patch(
             "claude_monitor.data.reader._create_unique_hash", return_value="hash_1"
         ):
-            result = _should_process_entry(data, None, set(), timezone_handler)
+            result = _should_process_entry(data, None, timezone_handler)
 
         assert result is True
 
@@ -539,9 +607,7 @@ class TestShouldProcessEntry:
             with patch(
                 "claude_monitor.data.reader._create_unique_hash", return_value="hash_1"
             ):
-                result = _should_process_entry(
-                    data, cutoff_time, set(), timezone_handler
-                )
+                result = _should_process_entry(data, cutoff_time, timezone_handler)
 
         assert result is True
 
@@ -558,22 +624,25 @@ class TestShouldProcessEntry:
             )
             mock_processor_class.return_value = mock_processor
 
-            result = _should_process_entry(data, cutoff_time, set(), timezone_handler)
+            result = _should_process_entry(data, cutoff_time, timezone_handler)
 
         assert result is False
 
-    def test_should_process_entry_with_duplicate_hash(self, timezone_handler):
+    def test_should_process_entry_keeps_repeated_keys(self, timezone_handler):
+        """A repeated key must reach the mapper.
+
+        Streaming writes several records under one key and the later ones hold
+        the complete usage, so filtering repeats out here would keep the
+        partial record. Selection now happens in _replaces_existing.
+        """
         data = {"message_id": "msg_1", "request_id": "req_1"}
-        processed_hashes = {"msg_1:req_1"}
 
         with patch(
             "claude_monitor.data.reader._create_unique_hash", return_value="msg_1:req_1"
         ):
-            result = _should_process_entry(
-                data, None, processed_hashes, timezone_handler
-            )
+            result = _should_process_entry(data, None, timezone_handler)
 
-        assert result is False
+        assert result is True
 
     def test_should_process_entry_no_timestamp(self, timezone_handler):
         data = {"message_id": "msg_1"}
@@ -582,7 +651,7 @@ class TestShouldProcessEntry:
         with patch(
             "claude_monitor.data.reader._create_unique_hash", return_value="hash_1"
         ):
-            result = _should_process_entry(data, cutoff_time, set(), timezone_handler)
+            result = _should_process_entry(data, cutoff_time, timezone_handler)
 
         assert result is True
 
@@ -600,9 +669,7 @@ class TestShouldProcessEntry:
             with patch(
                 "claude_monitor.data.reader._create_unique_hash", return_value="hash_1"
             ):
-                result = _should_process_entry(
-                    data, cutoff_time, set(), timezone_handler
-                )
+                result = _should_process_entry(data, cutoff_time, timezone_handler)
 
         assert result is True
 
@@ -647,29 +714,39 @@ class TestCreateUniqueHash:
         assert result is None
 
 
-class TestUpdateProcessedHashes:
-    """Test the _update_processed_hashes function."""
+class TestReplacesExisting:
+    """Test the rule that picks a winner between records sharing a key."""
 
-    def test_update_processed_hashes_valid_hash(self) -> None:
-        data = {"message_id": "msg_123", "request_id": "req_456"}
-        processed_hashes = set()
+    @staticmethod
+    def _entry(output: int, *, input_tokens: int = 10) -> UsageEntry:
+        return UsageEntry(
+            timestamp=datetime(2024, 1, 1, 12, 0, tzinfo=timezone.utc),
+            input_tokens=input_tokens,
+            output_tokens=output,
+            message_id="msg_1",
+            request_id="req_1",
+        )
 
-        with patch(
-            "claude_monitor.data.reader._create_unique_hash",
-            return_value="msg_123:req_456",
-        ):
-            _update_processed_hashes(data, processed_hashes)
+    def test_complete_record_replaces_partial(self) -> None:
+        """The finished record carries the larger output count."""
+        assert _replaces_existing(self._entry(3000), self._entry(5)) is True
 
-        assert "msg_123:req_456" in processed_hashes
+    def test_partial_record_does_not_replace_complete(self) -> None:
+        """Order of arrival must not decide the winner."""
+        assert _replaces_existing(self._entry(5), self._entry(3000)) is False
 
-    def test_update_processed_hashes_no_hash(self) -> None:
-        data = {"some": "data"}
-        processed_hashes = set()
+    def test_equal_output_falls_back_to_total(self) -> None:
+        """Main transcripts repeat identical output on every line."""
+        assert (
+            _replaces_existing(
+                self._entry(100, input_tokens=50), self._entry(100, input_tokens=10)
+            )
+            is True
+        )
 
-        with patch("claude_monitor.data.reader._create_unique_hash", return_value=None):
-            _update_processed_hashes(data, processed_hashes)
-
-        assert len(processed_hashes) == 0
+    def test_identical_records_do_not_replace(self) -> None:
+        """No churn when a record is simply restated unchanged."""
+        assert _replaces_existing(self._entry(100), self._entry(100)) is False
 
 
 class TestMapToUsageEntry:
@@ -1315,7 +1392,7 @@ class TestAdditionalEdgeCases:
         # Test with None cutoff_time and no hash
         data = {"some": "data"}
         with patch("claude_monitor.data.reader._create_unique_hash", return_value=None):
-            result = _should_process_entry(data, None, set(), timezone_handler)
+            result = _should_process_entry(data, None, timezone_handler)
         assert result is True
 
         # Test with empty processed_hashes set
@@ -1323,7 +1400,7 @@ class TestAdditionalEdgeCases:
         with patch(
             "claude_monitor.data.reader._create_unique_hash", return_value="msg_1:req_1"
         ):
-            result = _should_process_entry(data, None, set(), timezone_handler)
+            result = _should_process_entry(data, None, timezone_handler)
         assert result is True
 
     def test_map_to_usage_entry_error_scenarios(self):
@@ -1470,7 +1547,7 @@ class TestAdditionalEdgeCases:
                 empty_file,
                 CostMode.AUTO,
                 None,
-                set(),
+                {},
                 True,
                 timezone_handler,
                 pricing_calculator,


### PR DESCRIPTION
## Problem

`_should_process_entry` rejected every record after the first sharing a
`(message.id, requestId)` key. A streaming message is written as several records
under one key and the earlier ones carry a partial usage snapshot, so the partial
record was the one kept and the finished numbers were discarded.

## Why no test caught it

The loss is path dependent. @lizhuojunx86 measured it on a 76,806-line corpus in #158:

| transcript type | multi-line groups | usage identical on all lines | output tokens lost under first-wins |
|---|---|---|---|
| main | 9,025 | 100.0% | 0.00% |
| subagents/** | 15,367 | 21.1% | 95.33% |

Main transcripts repeat the final usage on every record, so the old behaviour was
harmless there and no main-transcript fixture could see it. Blended on that corpus,
first-wins loses 47.5% of output tokens.

It also hides from a spot check: the cache fields are byte-identical on every
record in both paths, so the all-fields gap is 0.45% while output alone is nearly
halved. Subagent transcripts do reach the reader, since discovery is `rglob` at
unbounded depth.

## Change

Selection moved out of the filter into `_replaces_existing`, applied after mapping.
`_process_single_file` now receives a winners map shared across the scan, so a key
restated in a later file resolves against the earlier record instead of being dropped.

**Maximum, not last read.** Within a file the two rules agree: across 12,831
differing groups measured per file, none is non-monotone in output and none
finishes below its own maximum, so the maximum record and the last record are the
same record. Across files only the maximum is well defined, because discovery is
an unordered traversal and a key restated after a resume would otherwise resolve
to whichever file the filesystem handed over first. The maximum therefore costs
nothing and removes the dependency, and it always lands on a record that was
actually written. ccusage (`should_replace_deduped_entry`) and tokscale
(`merge_claude_duplicate`) both settled on a maximum independently.

**Whole records.** A per-field maximum could assemble a record that was never
written, and `cost_usd` is derived from those fields, so the resulting cost would
correspond to no observation.

Records without a key keep their previous behaviour and are never deduplicated.
Raw entries are still collected once per key.

## Verification

@lizhuojunx86 ran this branch at d86350c against a byte-stable snapshot of his
own corpus, 1,588 transcripts and 31,215 entries loaded, and compared it to a
separate stdlib implementation written against the rule rather than against this
code:

| field | this reader | independent implementation |
|---|---|---|
| input_tokens | 3,949,048 | 3,949,048 |
| output_tokens | 35,351,212 | 35,351,212 |
| cache_creation | 251,399,530 | 251,399,530 |
| cache_read | 6,281,739,030 | 6,281,739,030 |

Exact on all four fields. For scale, a first-wins read of the same snapshot keeps
18,494,778 of those 35,351,212 output tokens, so on a subagent-heavy corpus this
change roughly doubles reported output.

## Scope

This addresses the first-record-wins half of #158. **It does not close #226.**
Records vanishing between scans is a different problem: nothing persists across
scans, so re-reading rewritten files still drifts. That is the warehouse question,
and this change is orthogonal to it, since `write_warehouse` flows into the same
load call and `upsert_entries` was receiving first-wins entries too.

## Checks

* `python3 -m pytest src/tests/`: 733 passed, 3 skipped (Windows-only)
* `python3 -m ruff check` on both changed files: all checks passed
* `python3 -m ruff format --check`: already formatted

Tests pin the two transcript shapes as separate fixtures rather than averaging
them, plus traversal-order independence and the selection rule itself.

Verified against the code: the finding is correct. If every occurrence of a key
fails to map, `deduped` never receives that key, `first_sighting` stays true, and
raw is appended once per occurrence instead of once.

It is not introduced here, though. On the parent commit the same shape existed:
`_update_processed_hashes` was called inside `if entry:`, so a key whose every
occurrence failed to map was never recorded either, `_should_process_entry`
returned true again on the next one, and raw was appended each time. Same
behaviour, same trigger, carried over unchanged by this PR.

That puts it out of scope for a change about which record survives, and fixing it
means another signature change to `_process_single_file` plus another pass over
the test call sites. @Maciek-roboblog happy to fold it in here if you would rather
have it in one go, otherwise I will open it separately once this lands.

One note for whoever takes it: raw entries being deduplicated at all looks like a
side effect of the old control flow rather than a decision. The docstring says raw
entries are never filtered because limit detection is model-agnostic; that is about
model filtering rather than about dedup, but the same reasoning would argue for
emitting every raw record and deduplicating none of them. Worth settling before
patching the symptom.