### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -1284,7 +1284,7 @@ A special thanks to our supporters who help keep this project going:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=Maciek-roboblog/Claude-Code-Usage-Monitor&type=Date)](https://www.star-history.com/#Maciek-roboblog/Claude-Code-Usage-Monitor&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=Maciek-roboblog/Claude-Code-Usage-Monitor&type=Date)](https://star-history.dera.page/#Maciek-roboblog/Claude-Code-Usage-Monitor&Date)
 
 ---
 


### PR DESCRIPTION
The star history chart in the README is broken because the upstream service relies on the GitHub stargazer API, which now restricts unauthenticated access. This switches the chart to a working mirror so the image renders again, while leaving the badge untouched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Star History chart image and link to use the new hosting domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->